### PR TITLE
fix: use main for bevy and ggrs instead of master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["network-programming", "game-development"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false }
-ggrs = { git = "https://github.com/gschup/ggrs" }
+bevy = { git = "https://github.com/bevyengine/bevy.git", branch = "main", default-features = false }
+ggrs = { git = "https://github.com/gschup/ggrs.git", branch = "main" }
 
 [dev-dependencies]
 structopt = "0.3"
-bevy = { git = "https://github.com/bevyengine/bevy"}
+bevy = { git = "https://github.com/bevyengine/bevy.git", branch = "main"}
 
 # Examples
 [[example]]


### PR DESCRIPTION
Update `Cargo.toml` dependency to use `main` instead of `master` since the example does not work nor can it be imported.