### PR TITLE
refactor!: Make with_input_system take an IntoSystem

### DIFF
--- a/examples/box_game/box_game_p2p.rs
+++ b/examples/box_game/box_game_p2p.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // define frequency of rollback game logic update
         .with_fps(FPS)
         // define system that represents your inputs as a byte vector, so GGRS can send the inputs around
-        .with_input_system(input.system())
+        .with_input_system(input)
         // register components that will be loaded/saved
         .register_rollback_type::<Transform>()
         .register_rollback_type::<Velocity>()

--- a/examples/box_game/box_game_spectator.rs
+++ b/examples/box_game/box_game_spectator.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // define frequency of rollback game logic update
         .with_fps(FPS)
         // define system that represents your inputs as a byte vector, so GGRS can send the inputs around (not actually sending anything in synctest)
-        .with_input_system(input.system())
+        .with_input_system(input)
         // register components that will be loaded/saved
         .register_rollback_type::<Transform>()
         .register_rollback_type::<Velocity>()

--- a/examples/box_game/box_game_synctest.rs
+++ b/examples/box_game/box_game_synctest.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // define frequency of rollback game logic update
         .with_fps(FPS)
         // define system that represents your inputs as a byte vector, so GGRS can send the inputs around
-        .with_input_system(input.system())
+        .with_input_system(input)
         // register components that will be loaded/saved
         .register_rollback_type::<Transform>()
         .register_rollback_type::<Velocity>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,9 @@ pub trait GGRSApp {
     fn with_p2p_spectator_session(&mut self, sess: P2PSpectatorSession) -> &mut Self;
 
     /// Registers a given system as the input system. This system should provide encoded inputs for a given player.
-    fn with_input_system(
+    fn with_input_system<Params>(
         &mut self,
-        input_fn: impl System<In = PlayerHandle, Out = Vec<u8>>,
+        input_system: impl IntoSystem<PlayerHandle, Vec<u8>, Params>,
     ) -> &mut Self;
 
     /// Sets the fixed update frequency
@@ -176,10 +176,11 @@ impl GGRSApp for App {
         self
     }
 
-    fn with_input_system(
+    fn with_input_system<Params>(
         &mut self,
-        mut input_system: impl System<In = PlayerHandle, Out = Vec<u8>>,
+        input_system: impl IntoSystem<PlayerHandle, Vec<u8>, Params>,
     ) -> &mut Self {
+        let mut input_system = input_system.system();
         input_system.initialize(&mut self.world);
         let ggrs_stage = self
             .schedule


### PR DESCRIPTION
Instead of a System.

Means you don't need to call .system() on the input system function.