### PR TITLE
feat: Add a way to stop sessions

### DIFF
--- a/src/ggrs_stage.rs
+++ b/src/ggrs_stage.rs
@@ -28,8 +28,15 @@ pub(crate) struct GGRSStage {
     run_slow: bool,
 }
 
+/// Marker resource that triggers resetting the stage session state
+pub(crate) struct GGRSStageResetSession;
+
 impl Stage for GGRSStage {
     fn run(&mut self, world: &mut World) {
+        if let Some(_) = world.remove_resource::<GGRSStageResetSession>() {
+            self.reset_session();
+        }
+
         // get delta time from last run() call and accumulate it
         let delta = Instant::now().duration_since(self.last_update);
         let mut fps_delta = 1. / self.fps as f64;
@@ -79,6 +86,13 @@ impl GGRSStage {
             accumulator: Duration::ZERO,
             run_slow: false,
         }
+    }
+
+    pub(crate) fn reset_session(&mut self) {
+        self.last_update = Instant::now();
+        self.accumulator = Duration::ZERO;
+        self.frame = 0;
+        self.run_slow = false;
     }
 
     fn run_synctest(&mut self, world: &mut World) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use bevy::{
     reflect::{FromType, GetTypeRegistration},
 };
 use ggrs::{P2PSession, P2PSpectatorSession, PlayerHandle, SessionState, SyncTestSession};
-use ggrs_stage::GGRSStage;
+use ggrs_stage::{GGRSStage, GGRSStageResetSession};
 use reflect_resource::ReflectResource;
 
 pub(crate) mod ggrs_stage;
@@ -315,6 +315,7 @@ pub trait CommandsExt {
     fn start_p2p_session(&mut self, session: P2PSession);
     fn start_p2p_spectator_session(&mut self, session: P2PSpectatorSession);
     fn start_synctest_session(&mut self, session: SyncTestSession);
+    fn stop_session(&mut self);
 }
 
 impl CommandsExt for Commands<'_, '_> {
@@ -328,6 +329,10 @@ impl CommandsExt for Commands<'_, '_> {
 
     fn start_synctest_session(&mut self, session: SyncTestSession) {
         self.add(StartSyncTestSessionCommand(session));
+    }
+
+    fn stop_session(&mut self) {
+        self.add(StopSessionCommand);
     }
 }
 
@@ -365,5 +370,17 @@ impl Command for StartSyncTestSessionCommand {
     fn write(self, world: &mut World) {
         world.insert_resource(self.0);
         world.insert_resource(SessionType::SyncTestSession);
+    }
+}
+
+struct StopSessionCommand;
+
+impl Command for StopSessionCommand {
+    fn write(self, world: &mut World) {
+        world.remove_resource::<SessionType>();
+        world.remove_resource::<P2PSession>();
+        world.remove_resource::<SyncTestSession>();
+        world.remove_resource::<P2PSpectatorSession>();
+        world.insert_resource(GGRSStageResetSession);
     }
 }


### PR DESCRIPTION
i.e.

commands.stop_session()

With this change it's possible to stop and start a new session without
recreating the bevy app.

The implementation is messy (with the marker resource), but it was the
easiest thing to do that I could think of at the moment. At least it's
private.