### PR TITLE
update for 0.8 with some more changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ bytemuck = { version = "1.7", features=["derive"]}
 instant = "0.1"
 log = "0.4"
 ggrs = { git = "https://github.com/gschup/ggrs", features=["sync-send"]}
+parking_lot = "0.12.1"
 
 [dev-dependencies]
 structopt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["network-programming", "game-development"]
 wasm-bindgen = ["instant/wasm-bindgen", "ggrs/wasm-bindgen"]
 
 [dependencies]
-bevy = { version = "0.7", default-features = false }
+bevy = { version = "0.8.0", default-features = false, features = ["render", "bevy_asset","bevy_scene",]}
 bytemuck = { version = "1.7", features=["derive"]}
 instant = "0.1"
 log = "0.4"
@@ -25,7 +25,7 @@ ggrs = { git = "https://github.com/gschup/ggrs", features=["sync-send"]}
 [dev-dependencies]
 structopt = "0.3"
 rand = "0.8.4"
-bevy = "0.7"
+bevy = "0.8.0"
 serde = "1.0.130"
 serde_json = "1.0"
 

--- a/examples/box_game/box_game.rs
+++ b/examples/box_game/box_game.rs
@@ -133,7 +133,7 @@ pub fn setup_system(
         ..Default::default()
     });
     // camera
-    commands.spawn_bundle(PerspectiveCameraBundle {
+    commands.spawn_bundle(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 7.5, 0.5).looking_at(Vec3::ZERO, Vec3::Y),
         ..Default::default()
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,13 @@
 
 use bevy::{
     prelude::*,
-    reflect::{FromType, GetTypeRegistration, TypeRegistry},
+    reflect::{FromType, GetTypeRegistration, TypeRegistry, TypeRegistryInternal},
 };
 use ggrs::{Config, PlayerHandle};
 use ggrs_stage::GGRSStage;
 use reflect_resource::ReflectResource;
+use std::sync::Arc;
+use parking_lot::RwLock;
 
 pub(crate) mod ggrs_stage;
 pub(crate) mod reflect_resource;
@@ -82,7 +84,9 @@ impl<T: Config + Send + Sync> Default for GGRSPlugin<T> {
         Self {
             input_system: None,
             fps: DEFAULT_FPS,
-            type_registry: Default::default(),
+            type_registry: TypeRegistry {
+                internal: Arc::new(RwLock::new(TypeRegistryInternal::empty())),
+            },
             schedule: Default::default(),
         }
     }

--- a/src/world_snapshot.rs
+++ b/src/world_snapshot.rs
@@ -87,7 +87,7 @@ impl WorldSnapshot {
                         .filter(|&&entity| world.get::<Rollback>(entity).is_some())
                         .enumerate()
                     {
-                        if let Some(component) = reflect_component.reflect_component(world, *entity)
+                        if let Some(component) = reflect_component.reflect(world, *entity)
                         {
                             assert_eq!(*entity, snapshot.entities[entities_offset + i].entity);
                             // add the hash value of that component to the shapshot checksum, if that component supports hashing
@@ -158,24 +158,24 @@ impl WorldSnapshot {
                     match rollback_entity
                         .components
                         .iter()
-                        .find(|comp| comp.type_name() == registration.name())
+                        .find(|comp| comp.type_name() == registration.short_name())
                     {
                         // if we have data saved in the snapshot, overwrite the world
                         Some(component) => {
-                            reflect_component.apply_component(world, entity, &**component)
+                            reflect_component.apply(world, entity, &**component)
                         }
                         // if we don't have any data saved, we need to remove that component from the entity
-                        None => reflect_component.remove_component(world, entity),
+                        None => reflect_component.remove(world, entity),
                     }
                 } else {
                     // the entity in the world has no such component
                     if let Some(component) = rollback_entity
                         .components
                         .iter()
-                        .find(|comp| comp.type_name() == registration.name())
+                        .find(|comp| comp.type_name() == registration.short_name())
                     {
                         // if we have data saved in the snapshot, add the component to the entity
-                        reflect_component.add_component(world, entity, &**component);
+                        reflect_component.insert(world, entity, &**component);
                     }
                     // if both the snapshot and the world does not have the registered component, we don't need to to anything
                 }
@@ -206,7 +206,7 @@ impl WorldSnapshot {
                     match self
                         .resources
                         .iter()
-                        .find(|res| res.type_name() == registration.name())
+                        .find(|res| res.type_name() == registration.short_name())
                     {
                         // if both the world and the snapshot has the resource, apply the values
                         Some(snapshot_res) => {
@@ -222,7 +222,7 @@ impl WorldSnapshot {
                     if let Some(snapshot_res) = self
                         .resources
                         .iter()
-                        .find(|res| res.type_name() == registration.name())
+                        .find(|res| res.type_name() == registration.short_name())
                     {
                         reflect_resource.add_resource(world, &**snapshot_res);
                     }

--- a/src/world_snapshot.rs
+++ b/src/world_snapshot.rs
@@ -158,7 +158,7 @@ impl WorldSnapshot {
                     match rollback_entity
                         .components
                         .iter()
-                        .find(|comp| comp.type_name() == registration.short_name())
+                        .find(|comp| comp.type_name() == registration.type_name())
                     {
                         // if we have data saved in the snapshot, overwrite the world
                         Some(component) => {
@@ -172,7 +172,7 @@ impl WorldSnapshot {
                     if let Some(component) = rollback_entity
                         .components
                         .iter()
-                        .find(|comp| comp.type_name() == registration.short_name())
+                        .find(|comp| comp.type_name() == registration.type_name())
                     {
                         // if we have data saved in the snapshot, add the component to the entity
                         reflect_component.insert(world, entity, &**component);
@@ -206,7 +206,7 @@ impl WorldSnapshot {
                     match self
                         .resources
                         .iter()
-                        .find(|res| res.type_name() == registration.short_name())
+                        .find(|res| res.type_name() == registration.type_name())
                     {
                         // if both the world and the snapshot has the resource, apply the values
                         Some(snapshot_res) => {
@@ -222,7 +222,7 @@ impl WorldSnapshot {
                     if let Some(snapshot_res) = self
                         .resources
                         .iter()
-                        .find(|res| res.type_name() == registration.short_name())
+                        .find(|res| res.type_name() == registration.type_name())
                     {
                         reflect_resource.add_resource(world, &**snapshot_res);
                     }


### PR DESCRIPTION
I tried to get #25 working and ran into some more issues. I don't know how to add more changes to someone else's PR, so here's a new one.

Apparently a bevy 0.8 TypeRegistry contains some primitive types by default, which caused a "Unregistered Type in GGRS Type Registry" panic. I couldn't find a convenient way to construct a TypeRegistryArc that's actually empty in the new docs, so we have to construct one directly?

I also had into short_name and type_name on a TypeRegistration actually returning different names for the same type. This made write_to_world overlook the components that were saved in the snapshot and delete them from the world instead.