### PR TITLE
Only Depend on Bevy `bevy_render` not `render`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["network-programming", "game-development"]
 wasm-bindgen = ["instant/wasm-bindgen", "ggrs/wasm-bindgen"]
 
 [dependencies]
-bevy = { version = "0.8.0", default-features = false, features = ["render", "bevy_asset","bevy_scene",]}
+bevy = { version = "0.8.0", default-features = false, features = ["bevy_render", "bevy_asset","bevy_scene",]}
 bytemuck = { version = "1.7", features=["derive"]}
 instant = "0.1"
 log = "0.4"


### PR DESCRIPTION
This removes this crate's dependency on the Bevy renderers such as `bevy_text`/`ui`/`pbr`, etc.

It definitely was a little unintuitive that the `render` feature is different than the `bevy_render` feature.