### PR TITLE
Add debug logging on snapshot save and restore

### DIFF
--- a/examples/box_game/box_game.rs
+++ b/examples/box_game/box_game.rs
@@ -110,11 +110,12 @@ pub fn setup_system(
         transform.translation.x = x;
         transform.translation.y = CUBE_SIZE / 2.;
         transform.translation.z = z;
+        let color = PLAYER_COLORS[handle % PLAYER_COLORS.len()];
 
         commands.spawn((
             PbrBundle {
                 mesh: meshes.add(Mesh::from(shape::Cube { size: CUBE_SIZE })),
-                material: materials.add(PLAYER_COLORS[handle as usize].into()),
+                material: materials.add(color.into()),
                 transform,
                 ..default()
             },
@@ -154,7 +155,7 @@ pub fn move_cube_system(
     inputs: Res<PlayerInputs<GGRSConfig>>,
 ) {
     for (mut t, mut v, p) in query.iter_mut() {
-        let input = inputs[p.handle as usize].0.inp;
+        let input = inputs[p.handle].0.inp;
         // set velocity through key presses
         if input & INPUT_UP != 0 && input & INPUT_DOWN == 0 {
             v.z -= MOVEMENT_SPEED;

--- a/examples/box_game/box_game_p2p.rs
+++ b/examples/box_game/box_game_p2p.rs
@@ -130,7 +130,7 @@ fn print_network_stats_system(
         if let Some(sess) = p2p_session {
             match sess.as_ref() {
                 Session::P2PSession(s) => {
-                    let num_players = s.num_players() as usize;
+                    let num_players = s.num_players();
                     for i in 0..num_players {
                         if let Ok(stats) = s.network_stats(i) {
                             println!("NetworkStats for player {}: {:?}", i, stats);

--- a/src/ggrs_stage.rs
+++ b/src/ggrs_stage.rs
@@ -112,7 +112,7 @@ impl<T: Config> GGRSStage<T> {
 
         // get inputs for all players
         let mut inputs = Vec::new();
-        for handle in 0..sess.num_players() as usize {
+        for handle in 0..sess.num_players() {
             inputs.push(self.input_system.run(handle, world));
         }
 

--- a/src/ggrs_stage.rs
+++ b/src/ggrs_stage.rs
@@ -215,6 +215,7 @@ impl<T: Config> GGRSStage<T> {
         frame: i32,
         world: &mut World,
     ) {
+        debug!("saving snapshot for frame {frame}");
         assert_eq!(self.frame, frame);
 
         // we make a snapshot of our world
@@ -229,6 +230,7 @@ impl<T: Config> GGRSStage<T> {
     }
 
     pub(crate) fn load_world(&mut self, frame: i32, world: &mut World) {
+        debug!("restoring snapshot for frame {frame}");
         self.frame = frame;
 
         // we get the correct snapshot
@@ -244,10 +246,12 @@ impl<T: Config> GGRSStage<T> {
         inputs: Vec<(T::Input, InputStatus)>,
         world: &mut World,
     ) {
+        debug!("advancing to frame: {}", self.frame + 1);
         world.insert_resource(PlayerInputs::<T>(inputs));
         self.schedule.run_once(world);
         world.remove_resource::<PlayerInputs<T>>();
         self.frame += 1;
+        debug!("frame {} completed", self.frame);
     }
 
     pub(crate) fn set_update_frequency(&mut self, update_frequency: usize) {


### PR DESCRIPTION
This makes it a lot easier to make sense of other bevy log messages and
tell which frame they belonged to.