### PR TITLE
feat: Add `RollbackIdProvider::next`

### DIFF
--- a/examples/box_game/box_game.rs
+++ b/examples/box_game/box_game.rs
@@ -122,7 +122,7 @@ pub fn setup_system(
             Player { handle },
             Velocity::default(),
             // this component indicates bevy_GGRS that parts of this entity should be saved and loaded
-            Rollback::new(rip.next_id()),
+            rip.next(),
         ));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,25 @@ impl RollbackIdProvider {
         self.next_id += 1;
         ret
     }
+
+    /// Returns a `Rollback` component with the next unused id
+    ///
+    /// Convenience for `Rollback::new(rollback_id_provider.next_id())`.
+    ///
+    /// ```
+    /// # use bevy::prelude::*;
+    /// use bevy_ggrs::{RollbackIdProvider};
+    ///
+    /// fn system_in_rollback_schedule(mut commands: Commands, mut rip: RollbackIdProvider) {
+    ///     commands.spawn((
+    ///         SpatialBundle::default(),
+    ///         rip.next(),
+    ///     ));
+    /// }
+    /// ```
+    pub fn next(&mut self) -> Rollback {
+        Rollback::new(self.next_id())
+    }
 }
 
 /// A builder to configure GGRS for a bevy app.


### PR DESCRIPTION
As discussed in #42 .

While this slightly cuts down on the boilerplate, it also slightly obfuscates what type of component (`Rollback`) were adding...

What do you think?