### PR TITLE
Updated Rollback Component to use Bevy Entity

### DIFF
--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -1,0 +1,26 @@
+use bevy::{prelude::{Component, Entity, World}, ecs::system::EntityCommand};
+
+/// Add this component to all entities you want to be loaded/saved on rollback.
+#[derive(Component, Hash, PartialEq, Eq, Clone, Copy, Debug)]
+pub struct RollbackFlag(Entity);
+
+impl Default for RollbackFlag {
+    fn default() -> Self {
+        Self::new(Entity::from_raw(0))
+    }
+}
+
+impl RollbackFlag {
+    pub fn new(entity: Entity) -> Self {
+        Self(entity)
+    }
+}
+
+/// An `EntityCommand` which adds a `RollbackFlag` component to an entity.
+pub struct Rollback;
+
+impl EntityCommand for Rollback {
+    fn write(self, id: Entity, world: &mut World) {
+        world.entity_mut(id).insert(RollbackFlag::new(id));
+    }
+}

--- a/tests/entity_mapping.rs
+++ b/tests/entity_mapping.rs
@@ -26,9 +26,9 @@ fn input_system(_: In<PlayerHandle>, mut delete_events: EventReader<DeleteChildE
 
 fn setup_system(mut commands: Commands) {
     commands
-        .spawn((Rollback::new(0), ParentEntity))
+        .spawn((RollbackFlag::new(Entity::from_raw(0)), ParentEntity))
         .with_children(|parent| {
-            parent.spawn((Rollback::new(1), ChildEntity));
+            parent.spawn((RollbackFlag::new(Entity::from_raw(1)), ChildEntity));
         });
 }
 


### PR DESCRIPTION
# Overview
This is an attempt to resolve #11 based on my proposal [here](https://github.com/gschup/bevy_ggrs/issues/11#issuecomment-1514147896). 

Please note this is my first contribution to the project (and one of first pull requests on a public project through GitHub!) so let me know if there's anything I can or need to do to help out from here!

# Changes

- Replaced the existing `Rollback` component with a new component `RollbackFlag` which contains an `Entity` as its discriminant instead of a `u32`.
- Replaced `RollbackIdProvider` with an `EntityCommand` `Rollback` which injects the appropriate `RollbackFlag` into an entity.
- Updated tests and examples to reflect changes.
- Moved `Rollback` related functionality into a separate module for maintainability.
- Resolves #11 

# Possible Concerns

- I've renamed `Rollback` to `RollbackFlag` to allow the `EntityCommand` to take the name `Rollback`. I believe this is a nicer syntax when adding the rollback functionality to an entity, but this would break existing queries expecting the name `Rollback`. See [box_game.rs Line 128](examples/box_game/box_game.rs#L128) and [box_game.rs Line 156](examples/box_game/box_game.rs#L156) for an example of this change.
- Documentation for how to use the `EntityCommand` `Rollback` should probably be added.