### PR TITLE
Fix add_rollback command extension

### DIFF
--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -1,7 +1,10 @@
-use bevy::{prelude::{Component, Entity, World}, ecs::system::{EntityCommand, EntityCommands}};
+use bevy::{
+    ecs::system::{EntityCommand, EntityCommands},
+    prelude::{Component, Entity, World},
+};
 
 /// This component flags an entity as being included in the rollback save/load schedule with GGRS.
-/// 
+///
 /// You must use the `AddRollbackCommand` when spawning an entity to add this component. Alternatively,
 /// you can use the `add_rollback()` extension method provided by `AddRollbackCommandExtension`.
 #[derive(Component, Hash, PartialEq, Eq, Clone, Copy, Debug)]

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -34,13 +34,13 @@ mod private {
 /// Extension trait for `EntityCommands` which adds the `add_rollback()` method.
 pub trait AddRollbackCommandExtension: private::AddRollbackCommandExtensionSeal {
     /// Adds an automatically generated `Rollback` component to this `Entity`.
-    fn add_rollback(self) -> Self;
+    fn add_rollback(&mut self) -> &mut Self;
 }
 
 impl<'w, 's, 'a> private::AddRollbackCommandExtensionSeal for EntityCommands<'w, 's, 'a> {}
 
 impl<'w, 's, 'a> AddRollbackCommandExtension for EntityCommands<'w, 's, 'a> {
-    fn add_rollback(mut self) -> Self {
+    fn add_rollback(&mut self) -> &mut Self {
         self.add(AddRollbackCommand);
         self
     }


### PR DESCRIPTION
I think I just made a mistake in my comment here: https://github.com/gschup/bevy_ggrs/pull/58#discussion_r1173584216

We should just do the same as what `.insert` does.

This makes the following work:

```rust
        commands
            .entity(tilemap_entity)
            .insert(
                TilemapBundle {
                    grid_size,
                    map_type,
                    size: tilemap_size,
                    storage: tile_storage,
                    texture: TilemapTexture::Single(sprites.white_pixel.clone()),
                    tile_size,
                    transform: tilemap_transform.with_z(SHIP_BACKGROUND_LAYER_DEPTH),
                    ..default()
                }
            )
            .add_rollback();
```