### PR TITLE
Use Bevy abstractions instead of using `instant` directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ wasm-bindgen = ["instant/wasm-bindgen", "ggrs/wasm-bindgen"]
 [dependencies]
 bevy = { version = "0.11", default-features = false}
 bytemuck = { version = "1.7", features=["derive"]}
-instant = "0.1"
+instant = { version = "0.1", optional = true }
 log = "0.4"
 ggrs = { version= "0.9.4", features=["sync-send"]}
 #ggrs = { git = "https://github.com/gschup/ggrs", features=["sync-send"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,9 @@ use bevy::{
     ecs::schedule::{LogLevel, ScheduleBuildSettings, ScheduleLabel},
     prelude::*,
     reflect::{FromType, GetTypeRegistration, TypeRegistry, TypeRegistryInternal},
-    utils::HashMap,
+    utils::{Duration, HashMap},
 };
 use ggrs::{Config, InputStatus, P2PSession, PlayerHandle, SpectatorSession, SyncTestSession};
-use instant::{Duration, Instant};
 use parking_lot::RwLock;
 use std::{marker::PhantomData, sync::Arc};
 use world_snapshot::RollbackSnapshots;
@@ -50,8 +49,6 @@ pub struct PlayerInputs<T: Config>(Vec<(T::Input, InputStatus)>);
 struct FixedTimestepData {
     /// fixed FPS our logic is running with
     pub fps: usize,
-    /// internal time control variables
-    last_update: Instant,
     /// accumulated time. once enough time has been accumulated, an update is executed
     accumulator: Duration,
     /// boolean to see if we should run slow to let remote clients catch up
@@ -62,7 +59,6 @@ impl Default for FixedTimestepData {
     fn default() -> Self {
         Self {
             fps: DEFAULT_FPS,
-            last_update: Instant::now(),
             accumulator: Duration::ZERO,
             run_slow: false,
         }

--- a/tests/entity_mapping.rs
+++ b/tests/entity_mapping.rs
@@ -1,8 +1,9 @@
-use bevy::{prelude::*, utils::HashMap};
-
+use bevy::{
+    prelude::*,
+    utils::{Duration, HashMap},
+};
 use bevy_ggrs::*;
 use ggrs::*;
-use instant::Duration;
 
 pub struct GgrsConfig;
 impl Config for GgrsConfig {


### PR DESCRIPTION
This should make writing integration tests easier, since we can then use `TimeUpdateStrategy::ManualDuration`.