### PR TITLE
Fix panic when `set_rollback_schedule_fps` is not called

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@ impl<C: Config> Plugin for GgrsPlugin<C> {
             .init_resource::<RollbackSnapshots>()
             .init_resource::<RollbackFrameCount>()
             .init_resource::<LocalPlayers>()
+            .init_resource::<FixedTimestepData>()
             .add_schedule(GgrsSchedule, schedule)
             .add_schedule(ReadInputs, Schedule::new())
             .add_systems(PreUpdate, ggrs_stage::run::<C>);


### PR DESCRIPTION
The resource was only added when modifying the FPS, so default FPS didn't work.

This was a regression in 57ceab38