### PR TITLE
Added Sensible Default `ggrs::Config` type `GgrsConfig`

### DIFF
--- a/examples/box_game/box_game_p2p.rs
+++ b/examples/box_game/box_game_p2p.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(num_players > 0);
 
     // create a GGRS session
-    let mut sess_build = SessionBuilder::<GgrsConfig>::new()
+    let mut sess_build = SessionBuilder::<BoxConfig>::new()
         .with_num_players(num_players)
         .with_desync_detection_mode(ggrs::DesyncDetection::On { interval: 10 }) // (optional) set how often to exchange state checksums
         .with_max_prediction_window(12) // (optional) set max prediction window
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sess = sess_build.start_p2p_session(socket)?;
 
     App::new()
-        .add_plugins(GgrsPlugin::<GgrsConfig>::default())
+        .add_plugins(GgrsPlugin::<BoxConfig>::default())
         // define frequency of rollback game logic update
         .set_rollback_schedule_fps(FPS)
         // this system will be executed as part of input reading
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn print_events_system(mut session: ResMut<Session<GgrsConfig>>) {
+fn print_events_system(mut session: ResMut<Session<BoxConfig>>) {
     match session.as_mut() {
         Session::P2P(s) => {
             for event in s.events() {
@@ -115,7 +115,7 @@ fn print_events_system(mut session: ResMut<Session<GgrsConfig>>) {
 fn print_network_stats_system(
     time: Res<Time>,
     mut timer: ResMut<NetworkStatsTimer>,
-    p2p_session: Option<Res<Session<GgrsConfig>>>,
+    p2p_session: Option<Res<Session<BoxConfig>>>,
 ) {
     // print only when timer runs out
     if timer.0.tick(time.delta()).just_finished() {

--- a/examples/box_game/box_game_spectator.rs
+++ b/examples/box_game/box_game_spectator.rs
@@ -31,12 +31,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a GGRS session
 
     let socket = UdpNonBlockingSocket::bind_to_port(opt.local_port)?;
-    let sess = SessionBuilder::<GgrsConfig>::new()
+    let sess = SessionBuilder::<BoxConfig>::new()
         .with_num_players(opt.num_players)
         .start_spectator_session(opt.host, socket);
 
     App::new()
-        .add_plugins(GgrsPlugin::<GgrsConfig>::default())
+        .add_plugins(GgrsPlugin::<BoxConfig>::default())
         // define frequency of rollback game logic update
         .set_rollback_schedule_fps(FPS)
         // this system will be executed as part of input reading
@@ -66,7 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn print_events_system(mut session: ResMut<Session<GgrsConfig>>) {
+fn print_events_system(mut session: ResMut<Session<BoxConfig>>) {
     match session.as_mut() {
         Session::Spectator(s) => {
             for event in s.events() {
@@ -80,7 +80,7 @@ fn print_events_system(mut session: ResMut<Session<GgrsConfig>>) {
 fn print_network_stats_system(
     time: Res<Time>,
     mut timer: ResMut<NetworkStatsTimer>,
-    p2p_session: Option<Res<Session<GgrsConfig>>>,
+    p2p_session: Option<Res<Session<BoxConfig>>>,
 ) {
     // print only when timer runs out
     if timer.0.tick(time.delta()).just_finished() {

--- a/examples/box_game/box_game_synctest.rs
+++ b/examples/box_game/box_game_synctest.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(opt.num_players > 0);
 
     // create a GGRS session
-    let mut sess_build = SessionBuilder::<GgrsConfig>::new()
+    let mut sess_build = SessionBuilder::<BoxConfig>::new()
         .with_num_players(opt.num_players)
         .with_check_distance(opt.check_distance)
         .with_input_delay(2); // (optional) set input delay for the local player
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sess = sess_build.start_synctest_session()?;
 
     App::new()
-        .add_plugins(GgrsPlugin::<GgrsConfig>::default())
+        .add_plugins(GgrsPlugin::<BoxConfig>::default())
         // define frequency of rollback game logic update
         .set_rollback_schedule_fps(FPS)
         // this system will be executed as part of input reading

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,10 @@ pub struct GgrsConfig<Input, Address = SocketAddr, State = u8> {
 
 impl<Input, Address, State> Config for GgrsConfig<Input, Address, State>
 where
-    Input: Send + Sync + 'static + PartialEq + bytemuck::Pod,
-    Address: Send + Sync + 'static + Debug + Hash + Eq + Clone,
-    State: Send + Sync + 'static + Clone,
+    Self: 'static,
+    Input: Send + Sync + PartialEq + bytemuck::Pod,
+    Address: Send + Sync + Debug + Hash + Eq + Clone,
+    State: Send + Sync + Clone,
 {
     type Input = Input;
     type State = State;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use bevy::{
 };
 use ggrs::{Config, InputStatus, P2PSession, PlayerHandle, SpectatorSession, SyncTestSession};
 use parking_lot::RwLock;
-use std::{marker::PhantomData, sync::Arc};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData, net::SocketAddr, sync::Arc};
 use world_snapshot::RollbackSnapshots;
 
 pub use ggrs;
@@ -22,10 +22,30 @@ pub(crate) mod world_snapshot;
 
 pub mod prelude {
     pub use crate::{
-        AddRollbackCommandExtension, GgrsApp, GgrsPlugin, GgrsSchedule, PlayerInputs, ReadInputs,
-        Rollback, Session,
+        AddRollbackCommandExtension, GgrsApp, GgrsConfig, GgrsPlugin, GgrsSchedule, PlayerInputs,
+        ReadInputs, Rollback, Session,
     };
     pub use ggrs::{GGRSEvent as GgrsEvent, PlayerType, SessionBuilder};
+}
+
+/// A sensible default [GGRS Config](`ggrs::Config`) type suitable for most applications.
+///
+/// If you require a more specialized configuration, you can create your own type implementing
+/// [`Config`](`ggrs::Config`).
+#[derive(Debug)]
+pub struct GgrsConfig<Input, Address = SocketAddr, State = u8> {
+    _phantom: PhantomData<(Input, Address, State)>,
+}
+
+impl<Input, Address, State> Config for GgrsConfig<Input, Address, State>
+where
+    Input: Send + Sync + 'static + PartialEq + bytemuck::Pod,
+    Address: Send + Sync + 'static + Debug + Hash + Eq + Clone,
+    State: Send + Sync + 'static + Clone,
+{
+    type Input = Input;
+    type State = State;
+    type Address = Address;
 }
 
 const DEFAULT_FPS: usize = 60;


### PR DESCRIPTION
# Objective

In the `box_game` example, there's a to-do related to `ggrs::Config`:

> `/// TODO: Find a way to hide the state type.`

## Solution

I've solved this to-do by creating a type `GgrsConfig`:

```rust
#[derive(Debug)]
pub struct GgrsConfig<Input, Address = SocketAddr, State = u8> {
    _phantom: PhantomData<(Input, Address, State)>,
}

impl<Input, Address, State> Config for GgrsConfig<Input, Address, State>
where
    Self: 'static,
    Input: Send + Sync + PartialEq + bytemuck::Pod,
    Address: Send + Sync + Debug + Hash + Eq + Clone,
    State: Send + Sync + Clone,
{
    type Input = Input;
    type State = State;
    type Address = Address;
}
```

Because `GgrsConfig` is a concrete type, it is allowed to have defaults for the type parameters `Input`, `State`, and `Address` required by `ggrs::Config`. As mentioned in the `box_game` example, `u8` for `State` is already taken as a default (since `State` is unused in Bevy). I also took the liberty of setting `Address` to `SocketAddr` as I believe that is the most common type that will be used by end users. These defaults allow the example game to use:

```rust
pub type BoxConfig = GgrsConfig<BoxInput>;
```

I show a type definition here, as I suspect end users would prefer this option for the sake of brevity. Because this is all done through the addition of a simple zero-sized-type, all existing applications can continue using their custom `Config` types if they want, with no breaking changes.
