### PR TITLE
Add a Baseline Mapping to Preserve Relationships

### DIFF
--- a/src/world_snapshot.rs
+++ b/src/world_snapshot.rs
@@ -140,6 +140,12 @@ impl WorldSnapshot {
         // Mapping of the old entity ids ( when snapshot was taken ) to new entity ids
         let mut entity_map = EntityMap::default();
 
+        // Include a no-op mapping as a baseline to preserve relationships between rollback and non-rollback entities
+        for entity in world.iter_entities() {
+            let entity = entity.id();
+            entity_map.insert(entity, entity);
+        }
+
         // first, we write all entities
         for rollback_entity in self.entities.iter() {
             // find the corresponding current entity or create new entity, if it doesn't exist

--- a/src/world_snapshot.rs
+++ b/src/world_snapshot.rs
@@ -255,7 +255,10 @@ impl WorldSnapshot {
 
         // For every type that reflects `MapEntities`, map the entities so that they reference the
         // new IDs after applying the snapshot.
-        for reflect_map_entities in type_registry.iter().filter_map(|reg| reg.data::<ReflectMapEntities>()) {
+        for reflect_map_entities in type_registry
+            .iter()
+            .filter_map(|reg| reg.data::<ReflectMapEntities>())
+        {
             reflect_map_entities.map_all_entities(world, &mut entity_map)
         }
 
@@ -273,7 +276,10 @@ impl WorldSnapshot {
         }
 
         // Map entities a second time, fixing dead entities
-        for reflect_map_entities in type_registry.iter().filter_map(|reg| reg.data::<ReflectMapEntities>()) {
+        for reflect_map_entities in type_registry
+            .iter()
+            .filter_map(|reg| reg.data::<ReflectMapEntities>())
+        {
             reflect_map_entities.map_all_entities(world, &mut entity_map)
         }
     }

--- a/src/world_snapshot.rs
+++ b/src/world_snapshot.rs
@@ -265,7 +265,10 @@ impl WorldSnapshot {
             reflect_map_entities.map_all_entities(world, &mut entity_map)
         }
 
-        // If the entity map is now larger than the set of rollback entities, then dead entities were created
+        // If the entity map is now larger than the set of rollback entities, then dead entities were created.
+        // TODO: This workaround is required because the current behavior of `map_all_entities` is to change all entities,
+        // creating dead entities instead of leaving them with their original value. If `EntityMapper` behavior changes,
+        // then this workaround may no longer be required.
         if entity_map.len() > rollback_entities.len() {
             // Reverse dead-mappings, no-op correct mappings
             for original_entity in entity_map.keys().collect::<Vec<_>>() {


### PR DESCRIPTION
# Objective

- Fixes #63

## Solution 1 (original)

Before populating the `EntityMap` used during rollback with tracked entities, all entities within the `World` are added as no-op mappings:

```rust
for entity in world.iter_entities() {
    let entity = entity.id();
    entity_map.insert(entity, entity); // no-op mapping
}
```

This does add additional overhead, so it may be worth pursuing alternate strategies, perhaps through a PR to Bevy itself.

## Solution 2 (current; suggestion from @johanhelsing)

Reverse the mappings for any dead entities, and apply the map again:

```rust
// At this point, the map should only contain rollback entities
debug_assert_eq!(entity_map.len(), rollback_entities.len());

// For every type that reflects `MapEntities`, map the entities so that they reference the
// new IDs after applying the snapshot.
for reflect_map_entities in type_registry
    .iter()
    .filter_map(|reg| reg.data::<ReflectMapEntities>())
{
    reflect_map_entities.map_all_entities(world, &mut entity_map)
}

// If the entity map is now larger than the set of rollback entities, then dead entities were created
if entity_map.len() > rollback_entities.len() {
    // Reverse dead-mappings, no-op correct mappings
    for original_entity in entity_map.keys().collect::<Vec<_>>() {
        let mapped_entity = entity_map.remove(original_entity).unwrap();

        if rollback_entities.remove(&original_entity) {
            // Rollback entity was correctly mapped; no-op
            entity_map.insert(mapped_entity, mapped_entity);
        } else {
            // An untracked bystander was mapped to a dead end; reverse
            entity_map.insert(mapped_entity, original_entity);
        }
    }

    // Map entities a second time, fixing dead entities
    for reflect_map_entities in type_registry
        .iter()
        .filter_map(|reg| reg.data::<ReflectMapEntities>())
    {
        reflect_map_entities.map_all_entities(world, &mut entity_map)
    }
}
```

This avoids the allocation of an `EntityMap` the size of all entities in the `World`, but does require running `map_all_entities` twice.