### PR TITLE
Removed Redundant `RwLock` and `Arc`; Removed `parking_lot` Dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ instant = { version = "0.1", optional = true }
 log = "0.4"
 ggrs = { version= "0.9.4", features=["sync-send"]}
 #ggrs = { git = "https://github.com/gschup/ggrs", features=["sync-send"]}
-parking_lot = "0.12.1"
 
 [dev-dependencies]
 structopt = "0.3"

--- a/src/world_snapshot.rs
+++ b/src/world_snapshot.rs
@@ -1,7 +1,7 @@
 use bevy::{
     ecs::{entity::EntityMap, reflect::ReflectMapEntities},
     prelude::*,
-    reflect::{Reflect, TypeRegistry},
+    reflect::{Reflect, TypeRegistryInternal},
     utils::HashMap,
 };
 use std::{fmt::Debug, num::Wrapping};
@@ -59,9 +59,8 @@ pub(crate) struct WorldSnapshot {
 }
 
 impl WorldSnapshot {
-    pub(crate) fn from_world(world: &World, type_registry: &TypeRegistry) -> Self {
+    pub(crate) fn from_world(world: &World, type_registry: &TypeRegistryInternal) -> Self {
         let mut snapshot = WorldSnapshot::default();
-        let type_registry = type_registry.read();
 
         // create a `RollbackEntity` for every entity tagged with rollback
         for archetype in world.archetypes().iter() {
@@ -133,8 +132,7 @@ impl WorldSnapshot {
         snapshot
     }
 
-    pub(crate) fn write_to_world(&self, world: &mut World, type_registry: &TypeRegistry) {
-        let type_registry = type_registry.read();
+    pub(crate) fn write_to_world(&self, world: &mut World, type_registry: &TypeRegistryInternal) {
         let mut rid_map = rollback_id_map(world);
 
         // Mapping of the old entity ids ( when snapshot was taken ) to new entity ids


### PR DESCRIPTION
# Objective

The `RollbackTypeRegistry` contains a `TypeRegistry`, which itself is a thin wrapper around `TypeRegistryInternal`, but through an `Arc<RwLock<...>>`. This indirection adds overhead to every interaction with the rollback type registry for no particular reason and should be removed. As a bonus, removing it would remove the need for the `parking_lot` dependency (still in the graph because of Bevy)

## Solution

Stored `TypeRegistryInternal` inside the `RollbackTypeRegistry` instead and removed lock acquisition code.