### PR TITLE
Add particles stress test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ggrs = { git = "https://github.com/gschup/ggrs", features=["sync-send"]}
 [dev-dependencies]
 clap = { version = "4.4", features = ["derive"] }
 rand = "0.8.4"
+rand_xoshiro = "0.6"
 bevy = "0.11"
 serde = "1.0.130"
 serde_json = "1.0"
@@ -43,3 +44,7 @@ path = "examples/box_game/box_game_spectator.rs"
 [[example]]
 name = "box_game_synctest"
 path = "examples/box_game/box_game_synctest.rs"
+
+[[example]]
+name = "particles"
+path = "examples/stress_tests/particles.rs"

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -1,0 +1,212 @@
+use bevy::{math::vec3, prelude::*, utils::HashMap, window::WindowResolution};
+use bevy_ggrs::{prelude::*, LocalInputs, LocalPlayers};
+use clap::Parser;
+use ggrs::UdpNonBlockingSocket;
+use rand::{Rng, SeedableRng};
+use std::net::SocketAddr;
+
+#[derive(Parser, Resource)]
+struct Args {
+    #[clap(short, long)]
+    local_port: u16,
+    #[clap(short, long, num_args = 1..)]
+    players: Vec<String>,
+    #[clap(short, long, num_args = 1..)]
+    spectators: Vec<SocketAddr>,
+    #[clap(short, long, default_value = "2")]
+    input_delay: usize,
+    #[clap(short, long, default_value = "10")]
+    desync_detection_interval: u32,
+    #[clap(short = 'n', long, default_value = "100")]
+    rate: u32,
+    #[clap(short, long, default_value = "60")]
+    fps: usize,
+    #[clap(long, default_value = "8")]
+    max_prediction: usize,
+}
+
+type Config = GgrsConfig<u8>;
+
+const INPUT_UP: u8 = 1 << 0;
+const INPUT_DOWN: u8 = 1 << 1;
+const INPUT_LEFT: u8 = 1 << 2;
+const INPUT_RIGHT: u8 = 1 << 3;
+
+fn read_local_inputs(
+    mut commands: Commands,
+    keyboard_input: Res<Input<KeyCode>>,
+    local_players: Res<LocalPlayers>,
+) {
+    let mut local_inputs = HashMap::new();
+
+    for handle in &local_players.0 {
+        let mut input: u8 = 0;
+
+        if keyboard_input.pressed(KeyCode::W) {
+            input |= INPUT_UP;
+        }
+        if keyboard_input.pressed(KeyCode::A) {
+            input |= INPUT_LEFT;
+        }
+        if keyboard_input.pressed(KeyCode::S) {
+            input |= INPUT_DOWN;
+        }
+        if keyboard_input.pressed(KeyCode::D) {
+            input |= INPUT_RIGHT;
+        }
+
+        local_inputs.insert(*handle, input);
+    }
+
+    commands.insert_resource(LocalInputs::<Config>(local_inputs));
+}
+
+#[derive(Default, Reflect, Component, Clone, Copy, Deref, DerefMut)]
+struct Velocity(Vec3);
+
+#[derive(Default, Reflect, Component, Clone, Copy, Deref, DerefMut)]
+struct Ttl(usize);
+
+type GameRng = rand_xoshiro::Xoshiro256PlusPlus;
+
+#[derive(Resource, Component, Clone, Deref, DerefMut)]
+struct ParticleRng(GameRng);
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let num_players = args.players.len();
+    assert!(num_players > 0);
+
+    let mut session_builder = SessionBuilder::<Config>::new()
+        .with_num_players(num_players)
+        .with_desync_detection_mode(ggrs::DesyncDetection::On {
+            interval: args.desync_detection_interval,
+        })
+        .with_max_prediction_window(args.max_prediction)?
+        .with_input_delay(args.input_delay);
+
+    for (i, player_addr) in args.players.iter().enumerate() {
+        if player_addr == "localhost" {
+            session_builder = session_builder.add_player(PlayerType::Local, i)?;
+        } else {
+            let remote_addr: SocketAddr = player_addr.parse()?;
+            session_builder = session_builder.add_player(PlayerType::Remote(remote_addr), i)?;
+        }
+    }
+
+    for (i, spec_addr) in args.spectators.iter().enumerate() {
+        session_builder =
+            session_builder.add_player(PlayerType::Spectator(*spec_addr), num_players + i)?;
+    }
+
+    let socket = UdpNonBlockingSocket::bind_to_port(args.local_port)?;
+    let session = session_builder.start_p2p_session(socket)?;
+
+    App::new()
+        .add_plugins(GgrsPlugin::<Config>::default())
+        .set_rollback_schedule_fps(args.fps)
+        .add_systems(ReadInputs, read_local_inputs)
+        // SpriteBundle types
+        .rollback_component_with_clone::<Sprite>()
+        .rollback_component_with_clone::<Transform>()
+        .rollback_component_with_clone::<GlobalTransform>()
+        .rollback_component_with_clone::<Handle<Image>>()
+        .rollback_component_with_clone::<Visibility>()
+        .rollback_component_with_clone::<ComputedVisibility>()
+        // Also add our own types
+        .rollback_component_with_copy::<Velocity>()
+        .rollback_component_with_copy::<Ttl>()
+        .rollback_resource_with_clone::<ParticleRng>()
+        .insert_resource(args)
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                resolution: WindowResolution::new(720., 720.),
+                title: "GGRS particles stress test".to_owned(),
+                ..default()
+            }),
+            ..default()
+        }))
+        .add_systems(Startup, setup)
+        .add_systems(Startup, spawn_particles) // spawn an initial burst of particles
+        .add_systems(
+            GgrsSchedule,
+            (
+                spawn_particles.run_if(any_input),
+                update_particles,
+                despawn_particles,
+            ),
+        )
+        .insert_resource(Session::P2P(session))
+        .insert_resource(ClearColor(Color::BLACK))
+        .insert_resource(ParticleRng(GameRng::seed_from_u64(123)))
+        .add_systems(Update, print_events_system)
+        .run();
+
+    Ok(())
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+}
+
+fn any_input(inputs: Res<PlayerInputs<Config>>) -> bool {
+    inputs.iter().any(|(i, _)| *i != 0)
+}
+
+fn spawn_particles(mut commands: Commands, args: Res<Args>, mut rng: ResMut<ParticleRng>) {
+    let s = 200.0;
+    let ttl = args.fps * 5;
+
+    for _ in 0..args.rate {
+        commands
+            .spawn((
+                SpriteBundle {
+                    sprite: Sprite {
+                        color: Color::ORANGE,
+                        custom_size: Some(Vec2::splat(5.0)),
+                        ..default()
+                    },
+                    ..default()
+                },
+                Velocity(vec3(rng.gen_range(-s..s), rng.gen_range(-s..s), 0.0)),
+                Ttl(ttl),
+            ))
+            .add_rollback();
+    }
+}
+
+fn update_particles(mut particles: Query<(&mut Transform, &mut Velocity)>, args: Res<Args>) {
+    let time_step = 1.0 / args.fps as f32; // todo: replace with bevy_ggrs resource?
+    let gravity = Vec3::NEG_Y * 200.0;
+
+    for (mut transform, mut velocity) in &mut particles {
+        **velocity += gravity * time_step;
+        transform.translation += **velocity * time_step;
+    }
+}
+
+fn despawn_particles(mut commands: Commands, mut particles: Query<(Entity, &mut Ttl)>) {
+    for (entity, mut ttl) in &mut particles {
+        **ttl -= 1;
+        if **ttl == 0 {
+            commands.entity(entity).despawn_recursive();
+        }
+    }
+}
+
+fn print_events_system(mut session: ResMut<Session<Config>>) {
+    match session.as_mut() {
+        Session::P2P(s) => {
+            for event in s.events() {
+                match event {
+                    GgrsEvent::Disconnected { .. } | GgrsEvent::NetworkInterrupted { .. } => {
+                        warn!("GGRS event: {event:?}")
+                    }
+                    GgrsEvent::DesyncDetected { .. } => error!("GGRS event: {event:?}"),
+                    _ => info!("GGRS event: {event:?}"),
+                }
+            }
+        }
+        _ => panic!("This example focuses on p2p."),
+    }
+}

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -5,7 +5,17 @@ use ggrs::{DesyncDetection, UdpNonBlockingSocket};
 use rand::{Rng, SeedableRng};
 use std::{hash::Hasher, net::SocketAddr};
 
-/// cargo watch -cx "run --release --example particles -- --local-port 7000 --players localhost 127.0.0.1:7001 --input-delay 0 --desync-detection-interval 1 --rate 1"
+/// Stress test for bevy_ggrs
+///
+/// ## Basic usage:
+///
+/// Player 1:
+///
+/// cargo run --release --example particles -- --local-port 7000 --players localhost 127.0.0.1:7001
+///
+/// Player 2:
+///
+/// cargo run --release --example particles -- --local-port 7001 --players 127.0.0.1:7001 localhost
 #[derive(Parser, Resource)]
 struct Args {
     /// The udp port to bind to for this peer.

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -1,7 +1,7 @@
 use bevy::{math::vec3, prelude::*, utils::HashMap, window::WindowResolution};
 use bevy_ggrs::{prelude::*, LocalInputs, LocalPlayers};
 use clap::Parser;
-use ggrs::UdpNonBlockingSocket;
+use ggrs::{DesyncDetection, UdpNonBlockingSocket};
 use rand::{Rng, SeedableRng};
 use std::{hash::Hasher, net::SocketAddr};
 
@@ -85,11 +85,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let num_players = args.players.len();
     assert!(num_players > 0);
 
+    let desync_mode = match args.desync_detection_interval {
+        0 => DesyncDetection::Off,
+        interval => DesyncDetection::On { interval },
+    };
+
     let mut session_builder = SessionBuilder::<Config>::new()
         .with_num_players(num_players)
-        .with_desync_detection_mode(ggrs::DesyncDetection::On {
-            interval: args.desync_detection_interval,
-        })
+        .with_desync_detection_mode(desync_mode)
         .with_max_prediction_window(args.max_prediction)?
         .with_input_delay(args.input_delay);
 

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -100,7 +100,7 @@ struct Velocity(Vec3);
 
 impl std::hash::Hash for Velocity {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // We should have no NaNs and infinite values in our simulation
+        // We should have no NaNs or infinite values in our simulation
         // as they're not deterministic.
         assert!(self.0.is_finite());
 

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -5,6 +5,7 @@ use ggrs::{DesyncDetection, UdpNonBlockingSocket};
 use rand::{Rng, SeedableRng};
 use std::{hash::Hasher, net::SocketAddr};
 
+/// cargo watch -cx "run --release --example particles -- --local-port 7000 --players localhost 127.0.0.1:7001 --input-delay 0 --desync-detection-interval 1 --rate 1"
 #[derive(Parser, Resource)]
 struct Args {
     /// The udp port to bind to for this peer.

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -100,6 +100,10 @@ struct Velocity(Vec3);
 
 impl std::hash::Hash for Velocity {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        // We should have no NaNs and infinite values in our simulation
+        // as they're not deterministic.
+        assert!(self.0.is_finite());
+
         self.0.x.to_bits().hash(state);
         self.0.y.to_bits().hash(state);
         self.0.z.to_bits().hash(state);

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -216,7 +216,12 @@ fn print_events_system(mut session: ResMut<Session<Config>>) {
                     GgrsEvent::Disconnected { .. } | GgrsEvent::NetworkInterrupted { .. } => {
                         warn!("GGRS event: {event:?}")
                     }
-                    GgrsEvent::DesyncDetected { .. } => error!("GGRS event: {event:?}"),
+                    GgrsEvent::DesyncDetected {
+                        local_checksum,
+                        remote_checksum,
+                        frame,
+                        ..
+                    } => panic!("Desync on frame {frame}. Local checksum: {local_checksum:X}, remote checksum: {remote_checksum:X}"),
                     _ => info!("GGRS event: {event:?}"),
                 }
             }


### PR DESCRIPTION
## Objective

We need some easy way of checking for performance regressions.

## Solution

- Add an example that spawns particles when either of the players holds down a key.
- Pass most parameters through command-line args

Depends on #76 and #77 

## todo:

- [x] checksumming
- [x] figure out why it desyncs
- [x] command-line options for using reflect-based snapshotting instead?