### PR TITLE
Applied Changes as Required for Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["network-programming", "game-development"]
 wasm-bindgen = ["instant/wasm-bindgen", "ggrs/wasm-bindgen"]
 
 [dependencies]
-bevy = { version = "0.11", default-features = false}
+bevy = { version = "0.12", default-features = false }
 bytemuck = { version = "1.7", features=["derive"]}
 instant = { version = "0.1", optional = true }
 log = "0.4"
@@ -24,10 +24,10 @@ log = "0.4"
 ggrs = { git = "https://github.com/gschup/ggrs", features=["sync-send"]}
 
 [dev-dependencies]
+bevy = { version = "0.12", default-features = true }
 clap = { version = "4.4", features = ["derive"] }
 rand = "0.8.4"
 rand_xoshiro = "0.6"
-bevy = "0.11"
 serde = "1.0.130"
 serde_json = "1.0"
 serial_test = "2.0"

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -164,7 +164,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .rollback_component_with_reflect::<GlobalTransform>()
             .rollback_component_with_reflect::<Handle<Image>>()
             .rollback_component_with_reflect::<Visibility>()
-            .rollback_component_with_reflect::<ComputedVisibility>()
+            .rollback_component_with_reflect::<InheritedVisibility>()
+            .rollback_component_with_reflect::<ViewVisibility>()
             // Also add our own types
             .rollback_component_with_reflect::<Velocity>()
             .rollback_component_with_reflect::<Ttl>()
@@ -181,7 +182,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .rollback_component_with_clone::<GlobalTransform>()
             .rollback_component_with_clone::<Handle<Image>>()
             .rollback_component_with_clone::<Visibility>()
-            .rollback_component_with_clone::<ComputedVisibility>()
+            .rollback_component_with_clone::<InheritedVisibility>()
+            .rollback_component_with_clone::<ViewVisibility>()
             // Also add our own types
             .rollback_component_with_copy::<Velocity>()
             .rollback_component_with_copy::<Ttl>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,20 +176,19 @@ impl<C: Config> Default for GgrsPlugin<C> {
 
 impl<C: Config> Plugin for GgrsPlugin<C> {
     fn build(&self, app: &mut App) {
-        let mut schedule = Schedule::default();
-        schedule.set_build_settings(ScheduleBuildSettings {
-            ambiguity_detection: LogLevel::Error,
-            ..default()
-        });
-
         app.init_resource::<RollbackFrameCount>()
             .init_resource::<ConfirmedFrameCount>()
             .init_resource::<MaxPredictionWindow>()
             .init_resource::<RollbackOrdered>()
             .init_resource::<LocalPlayers>()
             .init_resource::<FixedTimestepData>()
-            .add_schedule(GgrsSchedule, schedule)
-            .add_schedule(ReadInputs, Schedule::new())
+            .edit_schedule(GgrsSchedule, |schedule| {
+                schedule.set_build_settings(ScheduleBuildSettings {
+                    ambiguity_detection: LogLevel::Error,
+                    ..default()
+                });
+            })
+            .add_schedule(Schedule::new(ReadInputs))
             .add_systems(PreUpdate, schedule_systems::run_ggrs_schedules::<C>)
             .add_plugins((
                 SnapshotSetPlugin,

--- a/src/schedule_systems.rs
+++ b/src/schedule_systems.rs
@@ -149,21 +149,15 @@ pub(crate) fn handle_requests<T: Config>(requests: Vec<GGRSRequest<T>>, world: &
     // Extracting schedules before processing requests to avoid repeated remove/insert operations
     let mut schedules = world.resource_mut::<Schedules>();
 
-    let Some((extracted_load_world_label, mut load_world_schedule)) =
-        schedules.remove_entry(&LoadWorld)
-    else {
+    let Some((_, mut load_world_schedule)) = schedules.remove_entry(LoadWorld) else {
         panic!("Could not extract LoadWorld Schedule!");
     };
 
-    let Some((extracted_save_world_label, mut save_world_schedule)) =
-        schedules.remove_entry(&SaveWorld)
-    else {
+    let Some((_, mut save_world_schedule)) = schedules.remove_entry(SaveWorld) else {
         panic!("Could not extract SaveWorld Schedule!");
     };
 
-    let Some((extracted_advance_world_label, mut advance_world_schedule)) =
-        schedules.remove_entry(&GgrsSchedule)
-    else {
+    let Some((_, mut advance_world_schedule)) = schedules.remove_entry(GgrsSchedule) else {
         panic!("Could not extract GgrsSchedule Schedule!");
     };
 
@@ -254,17 +248,17 @@ pub(crate) fn handle_requests<T: Config>(requests: Vec<GGRSRequest<T>>, world: &
     // Replace Schedules when Done
     let mut schedules = world.resource_mut::<Schedules>();
 
-    let old = schedules.insert(extracted_load_world_label, load_world_schedule);
+    let old = schedules.insert(load_world_schedule);
     if old.is_some() {
         panic!("LoadWorld Schedule was Duplicated!");
     }
 
-    let old = schedules.insert(extracted_save_world_label, save_world_schedule);
+    let old = schedules.insert(save_world_schedule);
     if old.is_some() {
         panic!("SaveWorld Schedule was Duplicated!");
     }
 
-    let old = schedules.insert(extracted_advance_world_label, advance_world_schedule);
+    let old = schedules.insert(advance_world_schedule);
     if old.is_some() {
         panic!("GgrsSchedule Schedule was Duplicated!");
     }

--- a/src/snapshot/entity.rs
+++ b/src/snapshot/entity.rs
@@ -2,7 +2,7 @@ use crate::{
     GgrsComponentSnapshot, GgrsComponentSnapshots, LoadWorld, LoadWorldSet, Rollback,
     RollbackEntityMap, RollbackFrameCount, SaveWorld, SaveWorldSet,
 };
-use bevy::{ecs::entity::EntityMap, prelude::*, utils::HashMap};
+use bevy::{prelude::*, utils::HashMap};
 
 /// A [`Plugin`] which manages the rollback for [`Entities`](`Entity`). This will ensure
 /// all [`Entities`](`Entity`) match the state of the desired frame, or can be mapped using a
@@ -49,7 +49,7 @@ impl EntitySnapshotPlugin {
         frame: Res<RollbackFrameCount>,
         query: Query<(&Rollback, Entity)>,
     ) {
-        let mut entity_map = EntityMap::default();
+        let mut entity_map = HashMap::default();
         let mut rollback_mapping = HashMap::new();
 
         let snapshot = snapshots.rollback(frame.0).get();

--- a/src/snapshot/resource_map.rs
+++ b/src/snapshot/resource_map.rs
@@ -74,7 +74,7 @@ where
 {
     let mut applied_entity_map = map.generate_map();
 
-    applied_entity_map.world_scope(world, apply_map::<R>);
+    EntityMapper::world_scope(&mut applied_entity_map, world, apply_map::<R>);
 
     trace!(
         "Mapped {}",
@@ -87,8 +87,8 @@ where
     // then this workaround may no longer be required.
     if applied_entity_map.len() > map.len() {
         // Reverse dead-mappings, no-op correct mappings
-        for original in applied_entity_map.keys().collect::<Vec<_>>() {
-            let mapped = applied_entity_map.remove(original).unwrap();
+        for original in applied_entity_map.keys().copied().collect::<Vec<_>>() {
+            let mapped = applied_entity_map.remove(&original).unwrap();
 
             if map.get(original).is_some() {
                 // Rollback entity was correctly mapped; no-op
@@ -100,7 +100,7 @@ where
         }
 
         // Map entities a second time, fixing dead entities
-        applied_entity_map.world_scope(world, apply_map::<R>);
+        EntityMapper::world_scope(&mut applied_entity_map, world, apply_map::<R>);
 
         trace!(
             "Re-Mapped {}",

--- a/src/snapshot/rollback_entity_map.rs
+++ b/src/snapshot/rollback_entity_map.rs
@@ -1,19 +1,19 @@
-use bevy::{ecs::entity::EntityMap, prelude::*};
+use bevy::{prelude::*, utils::HashMap};
 
 /// A [`Resource`] which provides an [`EntityMap`], describing how [`Entities`](`Entity`)
 /// changed during a rollback.
 #[derive(Resource, Default)]
-pub struct RollbackEntityMap(EntityMap);
+pub struct RollbackEntityMap(HashMap<Entity, Entity>);
 
 impl RollbackEntityMap {
     /// Create a new [`RollbackEntityMap`], which can generate [`EntityMaps`](`EntityMap`) as required.
-    pub fn new(map: EntityMap) -> Self {
+    pub fn new(map: HashMap<Entity, Entity>) -> Self {
         Self(map)
     }
 
     /// Generate an owned [`EntityMap`], which can be used concurrently with other systems.
-    pub fn generate_map(&self) -> EntityMap {
-        let mut map = EntityMap::default();
+    pub fn generate_map(&self) -> HashMap<Entity, Entity> {
+        let mut map = HashMap::<Entity, Entity>::default();
 
         for (original, mapped) in self.iter() {
             map.insert(original, mapped);
@@ -25,13 +25,13 @@ impl RollbackEntityMap {
     /// Iterate over all [`Entity`] mappings as `(old, new)`
     pub fn iter(&self) -> impl Iterator<Item = (Entity, Entity)> + '_ {
         let Self(map) = self;
-        map.iter()
+        map.iter().map(|(&e1, &e2)| (e1, e2))
     }
 
     /// Get the mapping for a particular [`Entity`], if it exists.
     pub fn get(&self, entity: Entity) -> Option<Entity> {
         let Self(map) = self;
-        map.get(entity)
+        map.get(&entity).copied()
     }
 
     /// The quantity of mappings contained.

--- a/tests/entity_mapping.rs
+++ b/tests/entity_mapping.rs
@@ -22,7 +22,7 @@ struct ParentEntity;
 struct FrameCounter(u16);
 
 fn input_system(mut commands: Commands, mut delete_events: EventReader<DeleteChildEntityEvent>) {
-    let should_delete = u8::from(delete_events.iter().count() > 0);
+    let should_delete = u8::from(delete_events.read().count() > 0);
 
     let mut local_inputs = HashMap::new();
     local_inputs.insert(0, should_delete);


### PR DESCRIPTION
# Objective

Bare minimum changes required to move to Bevy 0.12 from 0.11.

# Solution

- Bumped Bevy to version 0.12
- Split `ComputedVisibility` into `ViewVisibility` and `InheritedVisibility`
- Updated `add_schedule` calls to use new convention
- Replaced `EntityMap` with `HashMap`