### PR TITLE
Support for Serde Rollback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ categories = ["network-programming", "game-development"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["serde"]
+default = ["serde", "ron", "bincode"]
 wasm-bindgen = ["instant/wasm-bindgen", "ggrs/wasm-bindgen"]
-serde = ["dep:serde", "dep:postcard"]
+serde = ["dep:serde"]
+ron = ["serde", "dep:ron"]
+bincode = ["serde", "dep:bincode"]
 
 [dependencies]
 bevy = { version = "0.12", default-features = false }
@@ -24,15 +26,16 @@ instant = { version = "0.1", optional = true }
 log = "0.4"
 #ggrs = { version= "0.9.4", features=["sync-send"]}
 ggrs = { git = "https://github.com/gschup/ggrs", features=["sync-send"]}
-serde = { version = "1.0.130", optional = true }
-postcard = { version = "1.0.8", optional = true, features = ["use-std", "alloc"] }
+serde = { version = "1", optional = true }
+ron = { version = "0.8", optional = true }
+bincode = { version = "1.3", optional = true }
 
 [dev-dependencies]
 bevy = { version = "0.12", default-features = true }
 clap = { version = "4.4", features = ["derive"] }
 rand = "0.8.4"
 rand_xoshiro = "0.6"
-serde = "1.0.130"
+serde = "1"
 serde_json = "1.0"
 serial_test = "2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ categories = ["network-programming", "game-development"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["serde"]
 wasm-bindgen = ["instant/wasm-bindgen", "ggrs/wasm-bindgen"]
+serde = ["dep:serde", "dep:postcard"]
 
 [dependencies]
 bevy = { version = "0.12", default-features = false }
@@ -22,6 +24,8 @@ instant = { version = "0.1", optional = true }
 log = "0.4"
 #ggrs = { version= "0.9.4", features=["sync-send"]}
 ggrs = { git = "https://github.com/gschup/ggrs", features=["sync-send"]}
+serde = { version = "1.0.130", optional = true }
+postcard = { version = "1.0.8", optional = true, features = ["use-std", "alloc"] }
 
 [dev-dependencies]
 bevy = { version = "0.12", default-features = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,20 @@ impl<C: Config> Plugin for GgrsPlugin<C> {
 /// Extension trait to add the GGRS plugin idiomatically to Bevy Apps
 pub trait GgrsApp {
     /// Registers a component type for saving and loading from the world. This
+    /// uses [Serde](`serde`) and [Postcard](`postcard`).
+    #[cfg(feature = "serde")]
+    fn rollback_component_with_postcard<Type>(&mut self) -> &mut Self
+    where
+        Type: Component + serde::Serialize + serde::de::DeserializeOwned;
+
+    /// Registers a resource type for saving and loading from the world. This
+    /// uses [Serde](`serde`) and [Postcard](`postcard`).
+    #[cfg(feature = "serde")]
+    fn rollback_resource_with_postcard<Type>(&mut self) -> &mut Self
+    where
+        Type: Resource + serde::Serialize + serde::de::DeserializeOwned;
+
+    /// Registers a component type for saving and loading from the world. This
     /// uses [`Copy`] based snapshots for rollback.
     fn rollback_component_with_copy<Type>(&mut self) -> &mut Self
     where
@@ -395,5 +409,21 @@ impl GgrsApp for App {
         Type: Resource,
     {
         self.add_plugins(ResourceChecksumPlugin::<Type>(hasher))
+    }
+    
+    #[cfg(feature = "serde")]
+    fn rollback_component_with_postcard<Type>(&mut self) -> &mut Self
+    where
+        Type: Component + serde::Serialize + serde::de::DeserializeOwned,
+    {
+        self.add_plugins(ComponentSnapshotPlugin::<PostcardStrategy<Type>>::default())
+    }
+
+    #[cfg(feature = "serde")]
+    fn rollback_resource_with_postcard<Type>(&mut self) -> &mut Self
+    where
+        Type: Resource + serde::Serialize + serde::de::DeserializeOwned,
+    {
+        self.add_plugins(ResourceSnapshotPlugin::<PostcardStrategy<Type>>::default())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,16 +229,30 @@ impl<C: Config> Plugin for GgrsPlugin<C> {
 /// Extension trait to add the GGRS plugin idiomatically to Bevy Apps
 pub trait GgrsApp {
     /// Registers a component type for saving and loading from the world. This
-    /// uses [Serde](`serde`) and [Postcard](`postcard`).
-    #[cfg(feature = "serde")]
-    fn rollback_component_with_postcard<Type>(&mut self) -> &mut Self
+    /// uses [Serde](`serde`) and [RON](`ron`).
+    #[cfg(feature = "ron")]
+    fn rollback_component_with_ron<Type>(&mut self) -> &mut Self
     where
         Type: Component + serde::Serialize + serde::de::DeserializeOwned;
 
     /// Registers a resource type for saving and loading from the world. This
-    /// uses [Serde](`serde`) and [Postcard](`postcard`).
-    #[cfg(feature = "serde")]
-    fn rollback_resource_with_postcard<Type>(&mut self) -> &mut Self
+    /// uses [Serde](`serde`) and [RON](`ron`).
+    #[cfg(feature = "ron")]
+    fn rollback_resource_with_ron<Type>(&mut self) -> &mut Self
+    where
+        Type: Resource + serde::Serialize + serde::de::DeserializeOwned;
+
+    /// Registers a component type for saving and loading from the world. This
+    /// uses [Serde](`serde`) and [bincode](`bincode`).
+    #[cfg(feature = "bincode")]
+    fn rollback_component_with_bincode<Type>(&mut self) -> &mut Self
+    where
+        Type: Component + serde::Serialize + serde::de::DeserializeOwned;
+
+    /// Registers a resource type for saving and loading from the world. This
+    /// uses [Serde](`serde`) and [bincode](`bincode`).
+    #[cfg(feature = "bincode")]
+    fn rollback_resource_with_bincode<Type>(&mut self) -> &mut Self
     where
         Type: Resource + serde::Serialize + serde::de::DeserializeOwned;
 
@@ -410,20 +424,36 @@ impl GgrsApp for App {
     {
         self.add_plugins(ResourceChecksumPlugin::<Type>(hasher))
     }
-    
-    #[cfg(feature = "serde")]
-    fn rollback_component_with_postcard<Type>(&mut self) -> &mut Self
+
+    #[cfg(feature = "ron")]
+    fn rollback_component_with_ron<Type>(&mut self) -> &mut Self
     where
         Type: Component + serde::Serialize + serde::de::DeserializeOwned,
     {
-        self.add_plugins(ComponentSnapshotPlugin::<PostcardStrategy<Type>>::default())
+        self.add_plugins(ComponentSnapshotPlugin::<RonStrategy<Type>>::default())
     }
 
-    #[cfg(feature = "serde")]
-    fn rollback_resource_with_postcard<Type>(&mut self) -> &mut Self
+    #[cfg(feature = "ron")]
+    fn rollback_resource_with_ron<Type>(&mut self) -> &mut Self
     where
         Type: Resource + serde::Serialize + serde::de::DeserializeOwned,
     {
-        self.add_plugins(ResourceSnapshotPlugin::<PostcardStrategy<Type>>::default())
+        self.add_plugins(ResourceSnapshotPlugin::<RonStrategy<Type>>::default())
+    }
+
+    #[cfg(feature = "bincode")]
+    fn rollback_component_with_bincode<Type>(&mut self) -> &mut Self
+    where
+        Type: Component + serde::Serialize + serde::de::DeserializeOwned,
+    {
+        self.add_plugins(ComponentSnapshotPlugin::<BincodeStrategy<Type>>::default())
+    }
+
+    #[cfg(feature = "bincode")]
+    fn rollback_resource_with_bincode<Type>(&mut self) -> &mut Self
+    where
+        Type: Resource + serde::Serialize + serde::de::DeserializeOwned,
+    {
+        self.add_plugins(ResourceSnapshotPlugin::<BincodeStrategy<Type>>::default())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,16 +229,30 @@ impl<C: Config> Plugin for GgrsPlugin<C> {
 /// Extension trait to add the GGRS plugin idiomatically to Bevy Apps
 pub trait GgrsApp {
     /// Registers a component type for saving and loading from the world. This
-    /// uses [Serde](`serde`) and [Postcard](`postcard`).
-    #[cfg(feature = "serde")]
-    fn rollback_component_with_postcard<Type>(&mut self) -> &mut Self
+    /// uses [Serde](`serde`) and [RON](`ron`).
+    #[cfg(feature = "ron")]
+    fn rollback_component_with_ron<Type>(&mut self) -> &mut Self
     where
         Type: Component + serde::Serialize + serde::de::DeserializeOwned;
 
     /// Registers a resource type for saving and loading from the world. This
-    /// uses [Serde](`serde`) and [Postcard](`postcard`).
-    #[cfg(feature = "serde")]
-    fn rollback_resource_with_postcard<Type>(&mut self) -> &mut Self
+    /// uses [Serde](`serde`) and [RON](`ron`).
+    #[cfg(feature = "ron")]
+    fn rollback_resource_with_ron<Type>(&mut self) -> &mut Self
+    where
+        Type: Resource + serde::Serialize + serde::de::DeserializeOwned;
+
+    /// Registers a component type for saving and loading from the world. This
+    /// uses [Serde](`serde`) and [bincode](`bincode`).
+    #[cfg(feature = "bincode")]
+    fn rollback_component_with_bincode<Type>(&mut self) -> &mut Self
+    where
+        Type: Component + serde::Serialize + serde::de::DeserializeOwned;
+
+    /// Registers a resource type for saving and loading from the world. This
+    /// uses [Serde](`serde`) and [bincode](`bincode`).
+    #[cfg(feature = "bincode")]
+    fn rollback_resource_with_bincode<Type>(&mut self) -> &mut Self
     where
         Type: Resource + serde::Serialize + serde::de::DeserializeOwned;
 
@@ -411,19 +425,35 @@ impl GgrsApp for App {
         self.add_plugins(ResourceChecksumPlugin::<Type>(hasher))
     }
     
-    #[cfg(feature = "serde")]
-    fn rollback_component_with_postcard<Type>(&mut self) -> &mut Self
+    #[cfg(feature = "ron")]
+    fn rollback_component_with_ron<Type>(&mut self) -> &mut Self
     where
         Type: Component + serde::Serialize + serde::de::DeserializeOwned,
     {
-        self.add_plugins(ComponentSnapshotPlugin::<PostcardStrategy<Type>>::default())
+        self.add_plugins(ComponentSnapshotPlugin::<RonStrategy<Type>>::default())
     }
 
-    #[cfg(feature = "serde")]
-    fn rollback_resource_with_postcard<Type>(&mut self) -> &mut Self
+    #[cfg(feature = "ron")]
+    fn rollback_resource_with_ron<Type>(&mut self) -> &mut Self
     where
         Type: Resource + serde::Serialize + serde::de::DeserializeOwned,
     {
-        self.add_plugins(ResourceSnapshotPlugin::<PostcardStrategy<Type>>::default())
+        self.add_plugins(ResourceSnapshotPlugin::<RonStrategy<Type>>::default())
+    }
+
+    #[cfg(feature = "bincode")]
+    fn rollback_component_with_bincode<Type>(&mut self) -> &mut Self
+    where
+        Type: Component + serde::Serialize + serde::de::DeserializeOwned,
+    {
+        self.add_plugins(ComponentSnapshotPlugin::<BincodeStrategy<Type>>::default())
+    }
+
+    #[cfg(feature = "bincode")]
+    fn rollback_resource_with_bincode<Type>(&mut self) -> &mut Self
+    where
+        Type: Resource + serde::Serialize + serde::de::DeserializeOwned,
+    {
+        self.add_plugins(ResourceSnapshotPlugin::<BincodeStrategy<Type>>::default())
     }
 }

--- a/src/snapshot/strategy.rs
+++ b/src/snapshot/strategy.rs
@@ -92,3 +92,35 @@ impl<T: Reflect + FromWorld> Strategy for ReflectStrategy<T> {
         target
     }
 }
+
+#[cfg(feature = "serde")]
+mod serde_strategy {
+    use std::marker::PhantomData;
+
+    use postcard::{from_bytes, to_allocvec};
+    use serde::{de::DeserializeOwned, Serialize};
+
+    use crate::Strategy;
+
+    /// A [`Strategy`] based on [`Reflect`] and [`FromWorld`]
+    pub struct PostcardStrategy<T: Serialize + DeserializeOwned>(PhantomData<T>);
+
+    impl<T: Serialize + DeserializeOwned> Strategy for PostcardStrategy<T> {
+        type Target = T;
+
+        type Stored = Vec<u8>;
+
+        #[inline(always)]
+        fn store(target: &Self::Target) -> Self::Stored {
+            to_allocvec(target).unwrap()
+        }
+
+        #[inline(always)]
+        fn load(stored: &Self::Stored) -> Self::Target {
+            from_bytes(stored).unwrap()
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+pub use serde_strategy::*;


### PR DESCRIPTION
# Objective

In my personal project, I've hit an issue where the [Rapier](https://github.com/dimforge/bevy_rapier) library has a large state object, `RapierContext`, which cannot be cloned, copied, or reflected for snapshotting. However, it does implement Serde `Serialize + Deserialize`. It would be convenient and broadly applicable if snapshots natively supported Serde.

# Solution

I've created an **optional** snapshot strategy using Serde and Postcard, gated by the newly added `serde` feature:

```rust
// With serde feature enabled
app.rollback_resource_with_postcard::<RapierContext>();
```

# Notes

I haven't done extensive performance testing with this strategy, but I think it's a safe bet it's probably the slowest. This is why I've chosen Postcard as the target format for de/serialization, as it is designed for embedded `no-std` use, where performance would be highly valued.

I also don't believe Rapier requires this addition to work, and this could also be added by an end user entirely through the current public API. However, I can imagine many others potentially reaching for this functionality, and I wrote it for myself, so I figured I might as well offer it here as well!

Finally, I've made this branch based off of my #83 for testing purposes, but these changes could be easily ported to any alternate Bevy 0.12 upgrade branch as required.