### PR TITLE
Add `checksum_hasher`

### DIFF
--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -1,10 +1,10 @@
 use bevy::{math::vec3, prelude::*, utils::HashMap, window::WindowResolution};
-use bevy_ggrs::{prelude::*, LocalInputs, LocalPlayers};
+use bevy_ggrs::{checksum_hasher, prelude::*, LocalInputs, LocalPlayers};
 use clap::Parser;
 use ggrs::{DesyncDetection, UdpNonBlockingSocket};
 use rand::{Rng, SeedableRng};
 use std::{
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{Hash, Hasher},
     net::SocketAddr,
 };
 
@@ -201,7 +201,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .checksum_component_with_hash::<Velocity>()
         // ...or you can provide a custom hashing process
         .checksum_component::<Transform>(|transform| {
-            let mut hasher = bevy::utils::FixedState.build_hasher();
+            let mut hasher = checksum_hasher();
 
             // In this demo we only translate particles, so only that value
             // needs to be tracked.

--- a/src/snapshot/checksum.rs
+++ b/src/snapshot/checksum.rs
@@ -1,11 +1,11 @@
 use std::{
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{Hash, Hasher},
     marker::PhantomData,
 };
 
 use bevy::prelude::*;
 
-use crate::{SaveWorld, SaveWorldSet};
+use crate::{checksum_hasher, SaveWorld, SaveWorldSet};
 
 /// Flags an entity as containing a checksum for a type `T`
 #[derive(Component)]
@@ -26,9 +26,9 @@ impl<T> Default for ChecksumFlag<T> {
 pub struct ChecksumPart(pub u128);
 
 impl ChecksumPart {
-    /// Converts a provided value `T` into a [Hash] using Bevy's [`FixedState`](`bevy::utils::FixedState`) hasher.
+    /// Converts a provided value `T` into a [Hash] using [`checksum_hasher`].
     pub fn from_value<T: Hash>(value: &T) -> Self {
-        let mut hasher = bevy::utils::FixedState.build_hasher();
+        let mut hasher = checksum_hasher();
 
         value.hash(&mut hasher);
 

--- a/src/snapshot/component_checksum.rs
+++ b/src/snapshot/component_checksum.rs
@@ -1,8 +1,10 @@
-use std::hash::{BuildHasher, Hash, Hasher};
+use std::hash::{Hash, Hasher};
 
 use bevy::prelude::*;
 
-use crate::{ChecksumFlag, ChecksumPart, Rollback, RollbackOrdered, SaveWorld, SaveWorldSet};
+use crate::{
+    checksum_hasher, ChecksumFlag, ChecksumPart, Rollback, RollbackOrdered, SaveWorld, SaveWorldSet,
+};
 
 /// A [`Plugin`] which will track the [`Component`] `C` on [`Rollback Entities`](`Rollback`) and ensure a
 /// [`ChecksumPart`] is available and updated. This can be used to generate a [`Checksum`](`crate::Checksum`).
@@ -33,7 +35,7 @@ use crate::{ChecksumFlag, ChecksumPart, Rollback, RollbackOrdered, SaveWorld, Sa
 pub struct ComponentChecksumPlugin<C: Component>(pub for<'a> fn(&'a C) -> u64);
 
 fn default_hasher<C: Component + Hash>(component: &C) -> u64 {
-    let mut hasher = bevy::utils::FixedState.build_hasher();
+    let mut hasher = checksum_hasher();
     component.hash(&mut hasher);
     hasher.finish()
 }
@@ -64,7 +66,7 @@ where
             &mut ChecksumPart,
             (Without<Rollback>, With<ChecksumFlag<C>>),
         >| {
-            let mut hasher = bevy::utils::FixedState.build_hasher();
+            let mut hasher = checksum_hasher();
 
             let mut result = 0;
 

--- a/src/snapshot/entity_checksum.rs
+++ b/src/snapshot/entity_checksum.rs
@@ -1,8 +1,10 @@
-use std::hash::{BuildHasher, Hash, Hasher};
+use std::hash::{Hash, Hasher};
 
 use bevy::prelude::*;
 
-use crate::{ChecksumFlag, ChecksumPart, Rollback, RollbackOrdered, SaveWorld, SaveWorldSet};
+use crate::{
+    checksum_hasher, ChecksumFlag, ChecksumPart, Rollback, RollbackOrdered, SaveWorld, SaveWorldSet,
+};
 
 pub struct EntityChecksumPlugin;
 
@@ -14,7 +16,7 @@ impl EntityChecksumPlugin {
         active_entities: Query<&Rollback, (With<Rollback>, Without<ChecksumFlag<Entity>>)>,
         mut checksum: Query<&mut ChecksumPart, (Without<Rollback>, With<ChecksumFlag<Entity>>)>,
     ) {
-        let mut hasher = bevy::utils::FixedState.build_hasher();
+        let mut hasher = checksum_hasher();
 
         // The quantity of active rollback entities must be synced.
         active_entities.iter().len().hash(&mut hasher);

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -1,6 +1,9 @@
 use crate::{ConfirmedFrameCount, Rollback, DEFAULT_FPS};
-use bevy::{prelude::*, utils::HashMap};
-use std::{collections::VecDeque, marker::PhantomData};
+use bevy::{
+    prelude::*,
+    utils::{AHasher, FixedState, HashMap},
+};
+use std::{collections::VecDeque, hash::BuildHasher, marker::PhantomData};
 
 mod checksum;
 mod component_checksum;
@@ -237,4 +240,9 @@ impl<For, As> GgrsComponentSnapshot<For, As> {
     pub fn iter(&self) -> impl Iterator<Item = (&Rollback, &As)> + '_ {
         self.snapshot.iter()
     }
+}
+
+/// Returns a hasher built using Bevy's [FixedState] appropriate for creating checksums
+pub fn checksum_hasher() -> AHasher {
+    FixedState.build_hasher()
 }

--- a/src/snapshot/resource_checksum.rs
+++ b/src/snapshot/resource_checksum.rs
@@ -1,8 +1,8 @@
-use std::hash::{BuildHasher, Hash, Hasher};
+use std::hash::{Hash, Hasher};
 
 use bevy::prelude::*;
 
-use crate::{ChecksumFlag, ChecksumPart, Rollback, SaveWorld, SaveWorldSet};
+use crate::{checksum_hasher, ChecksumFlag, ChecksumPart, Rollback, SaveWorld, SaveWorldSet};
 
 /// Plugin which will track the [`Resource`] `R` and ensure a [`ChecksumPart`] is
 /// available and updated. This can be used to generate a [`Checksum`](`crate::Checksum`).
@@ -33,7 +33,7 @@ use crate::{ChecksumFlag, ChecksumPart, Rollback, SaveWorld, SaveWorldSet};
 pub struct ResourceChecksumPlugin<R: Resource>(pub for<'a> fn(&'a R) -> u64);
 
 fn default_hasher<R: Resource + Hash>(resource: &R) -> u64 {
-    let mut hasher = bevy::utils::FixedState.build_hasher();
+    let mut hasher = checksum_hasher();
     resource.hash(&mut hasher);
     hasher.finish()
 }


### PR DESCRIPTION
Add a `checksum_hasher` convenience function for creating bevy's `FixedState` hasher.

Makes it a little less boiler-plate heavy to add checksumming plugins (see particles example).

Bonus: If we ever want to change the hasher it's just one place.
