### PR TITLE
Schedule systems after input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use bevy::{
         entity::MapEntities,
         schedule::{ExecutorKind, LogLevel, ScheduleBuildSettings, ScheduleLabel},
     },
+    input::InputSystem,
     prelude::*,
     utils::{Duration, HashMap},
 };
@@ -210,7 +211,10 @@ impl<C: Config> Plugin for GgrsPlugin<C> {
                     ..default()
                 });
             })
-            .add_systems(PreUpdate, schedule_systems::run_ggrs_schedules::<C>)
+            .add_systems(
+                PreUpdate,
+                schedule_systems::run_ggrs_schedules::<C>.after(InputSystem),
+            )
             .add_plugins((
                 SnapshotSetPlugin,
                 ChecksumPlugin,


### PR DESCRIPTION
Bevy's input systems run in `PreUpdate` in the `InputSystem` set. This ensures that the `ReadInputs` schedule runs after input is updated for the frame.