### PR TITLE
Fix example box_game_spectator.rs

### DIFF
--- a/examples/box_game/box_game_spectator.rs
+++ b/examples/box_game/box_game_spectator.rs
@@ -16,7 +16,7 @@ struct Opt {
     local_port: u16,
     #[clap(short, long)]
     num_players: usize,
-    #[clap(short, long)]
+    #[clap(long)]
     host: SocketAddr,
 }
 


### PR DESCRIPTION
I was getting an error due to conflicting flags, since `-h` is reserved as the short for `--help`, it can't be used as the short for `host`

```
> cargo run --example box_gam
e_spectator -- --local-port 7002 --num-players 2 --host 127
.0.0.1:7000
   Compiling bevy_ggrs v0.14.0 (/home/az/dev/bevy_ggrs)
    Finished dev [unoptimized + debuginfo] target(s) in 15.43s
     Running `target/debug/examples/box_game_spectator --local-port 7002 --num-players 2 --host '127.0.0.1:7000'`
thread 'main' panicked at /home/az/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.4.18/src/builder/debug_asserts.rs:112:17:
Command bevy_ggrs: Short option names must be unique for each argument, but '-h' is in use by both 'host' and 'help' (call `cmd.disable_help_flag(true)` to remove the auto-generated `--help`)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
