### PR TITLE
Fix checksum portability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ wasm-bindgen = ["instant/wasm-bindgen", "ggrs/wasm-bindgen"]
 
 [dependencies]
 bevy = { version = "0.12", default-features = false }
-bytemuck = { version = "1.7", features=["derive"]}
+bytemuck = { version = "1.7", features = ["derive"] }
 instant = { version = "0.1", optional = true }
 log = "0.4"
 #ggrs = { version= "0.10.0", features=["sync-send"]}
-ggrs = { git = "https://github.com/gschup/ggrs", features=["sync-send"]}
+ggrs = { git = "https://github.com/gschup/ggrs", features = ["sync-send"] }
+seahash = "4.1"
 
 [dev-dependencies]
 bevy = { version = "0.12", default-features = true }

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -56,7 +56,7 @@ impl<'w, 's, 'a> AddRollbackCommandExtension for EntityCommands<'w, 's, 'a> {
 /// A [`Resource`] which provides methods for stable ordering of [`Rollback`] flags.
 #[derive(Resource, Default, Clone)]
 pub struct RollbackOrdered {
-    order: HashMap<Rollback, usize>,
+    order: HashMap<Rollback, u64>,
     sorted: Vec<Rollback>,
 }
 
@@ -64,7 +64,7 @@ impl RollbackOrdered {
     /// Register a new [`Rollback`] for explicit ordering.
     fn push(&mut self, rollback: Rollback) -> &mut Self {
         self.sorted.push(rollback);
-        self.order.insert(rollback, self.sorted.len() - 1);
+        self.order.insert(rollback, self.sorted.len() as u64 - 1);
 
         self
     }
@@ -75,7 +75,7 @@ impl RollbackOrdered {
     }
 
     /// Returns a unique and order stable index for the provided [`Rollback`].
-    pub fn order(&self, rollback: Rollback) -> usize {
+    pub fn order(&self, rollback: Rollback) -> u64 {
         self.order
             .get(&rollback)
             .copied()

--- a/src/snapshot/component_checksum.rs
+++ b/src/snapshot/component_checksum.rs
@@ -71,7 +71,7 @@ where
             let mut result = 0;
 
             for (&rollback, component) in components.iter() {
-                let mut hasher = hasher.clone();
+                let mut hasher = hasher;
 
                 // Hashing the rollback index ensures this hash is unique and stable
                 rollback_ordered.order(rollback).hash(&mut hasher);

--- a/src/snapshot/entity_checksum.rs
+++ b/src/snapshot/entity_checksum.rs
@@ -19,10 +19,10 @@ impl EntityChecksumPlugin {
         let mut hasher = checksum_hasher();
 
         // The quantity of active rollback entities must be synced.
-        active_entities.iter().len().hash(&mut hasher);
+        (active_entities.iter().len() as u64).hash(&mut hasher);
 
         // The quantity of total spawned rollback entities must be synced.
-        rollback_ordered.len().hash(&mut hasher);
+        (rollback_ordered.len() as u64).hash(&mut hasher);
 
         let result = ChecksumPart(hasher.finish() as u128);
 

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -1,9 +1,7 @@
 use crate::{ConfirmedFrameCount, Rollback, DEFAULT_FPS};
-use bevy::{
-    prelude::*,
-    utils::{AHasher, FixedState, HashMap},
-};
-use std::{collections::VecDeque, hash::BuildHasher, marker::PhantomData};
+use bevy::{prelude::*, utils::HashMap};
+use seahash::SeaHasher;
+use std::{collections::VecDeque, marker::PhantomData};
 
 mod checksum;
 mod component_checksum;
@@ -242,7 +240,7 @@ impl<For, As> GgrsComponentSnapshot<For, As> {
     }
 }
 
-/// Returns a hasher built using Bevy's [FixedState] appropriate for creating checksums
-pub fn checksum_hasher() -> AHasher {
-    FixedState.build_hasher()
+/// Returns a hasher built using the `seahash` library appropriate for creating portable checksums.
+pub fn checksum_hasher() -> SeaHasher {
+    SeaHasher::new()
 }


### PR DESCRIPTION
This PR fixes checksum portability across different architectures by:
1. Replacing the usage of `usize` with `u64` in places where these numbers were hashed.
2. Switching the hasher implementation from the Bevy-provided, non-portable `AHash` hasher to the portable `seahash` hasher. 

Fixes https://github.com/gschup/bevy_ggrs/issues/98.