### PR TITLE
WIP Despawn using a disabling component

### DIFF
--- a/src/snapshot/despawn.rs
+++ b/src/snapshot/despawn.rs
@@ -35,13 +35,10 @@
 use crate::snapshot::despawn::private::RollbackDespawnCommandExtensionSeal;
 use crate::{
     AdvanceWorld, AdvanceWorldSystems, ConfirmedFrameCount, LoadWorld, LoadWorldSystems,
-    RollbackFrameCount, SaveWorld, SaveWorldSystems,
+    RollbackFrameCount,
 };
 use bevy::app::{App, Plugin};
-use bevy::prelude::{
-    Children, Component, Entity, EntityCommands, EntityMut, EntityRef, EntityWorldMut,
-    IntoScheduleConfigs, Local, Query, QueryState, Res, World,
-};
+use bevy::prelude::*;
 use ggrs::Frame;
 use std::cmp::Ordering;
 

--- a/src/snapshot/despawn.rs
+++ b/src/snapshot/despawn.rs
@@ -32,12 +32,18 @@
 //! Entities which have been marked for despawn are disabled using the [`RollbackDespawned`]
 //! component, so they will appear as though they are despawned to normal system queries.
 
-use std::cmp::Ordering;
-use bevy::app::{App, Plugin};
-use bevy::prelude::{Children, Component, Entity, EntityCommands, EntityMut, EntityRef, EntityWorldMut, IntoScheduleConfigs, Local, Query, QueryState, Res, World};
-use ggrs::Frame;
-use crate::{AdvanceWorld, AdvanceWorldSystems, ConfirmedFrameCount, LoadWorld, LoadWorldSystems, RollbackFrameCount, SaveWorld, SaveWorldSystems};
 use crate::snapshot::despawn::private::RollbackDespawnCommandExtensionSeal;
+use crate::{
+    AdvanceWorld, AdvanceWorldSystems, ConfirmedFrameCount, LoadWorld, LoadWorldSystems,
+    RollbackFrameCount, SaveWorld, SaveWorldSystems,
+};
+use bevy::app::{App, Plugin};
+use bevy::prelude::{
+    Children, Component, Entity, EntityCommands, EntityMut, EntityRef, EntityWorldMut,
+    IntoScheduleConfigs, Local, Query, QueryState, Res, World,
+};
+use ggrs::Frame;
+use std::cmp::Ordering;
 
 /// Marks an entity as despawned, contains the frame that the entity was despawned on.
 ///
@@ -54,8 +60,14 @@ impl Plugin for RollbackDespawnPlugin {
     fn build(&self, app: &mut App) {
         app.register_disabling_component::<RollbackDespawned>();
 
-        app.add_systems(LoadWorld, resurrect_entities.in_set(LoadWorldSystems::EntityResurrect))
-            .add_systems(AdvanceWorld, despawn_confirmed_entities.in_set(AdvanceWorldSystems::DespawnConfirmed));
+        app.add_systems(
+            LoadWorld,
+            resurrect_entities.in_set(LoadWorldSystems::EntityResurrect),
+        )
+        .add_systems(
+            AdvanceWorld,
+            despawn_confirmed_entities.in_set(AdvanceWorldSystems::DespawnConfirmed),
+        );
     }
 }
 
@@ -74,7 +86,9 @@ fn resurrect_entities(
         })
         .collect::<Vec<_>>()
         .into_iter()
-        .for_each(|entity| { world.entity_mut(entity).remove::<RollbackDespawned>(); });
+        .for_each(|entity| {
+            world.entity_mut(entity).remove::<RollbackDespawned>();
+        });
 }
 
 fn despawn_confirmed_entities(
@@ -97,7 +111,9 @@ fn despawn_confirmed_entities(
         })
         .collect::<Vec<_>>()
         .into_iter()
-        .for_each(|entity| { world.despawn(entity); });
+        .for_each(|entity| {
+            world.despawn(entity);
+        });
 }
 
 mod private {

--- a/src/snapshot/despawn.rs
+++ b/src/snapshot/despawn.rs
@@ -1,0 +1,169 @@
+//! Rollback entity deferred despawning module.
+//!
+//! This module allows rollback entities to have non-rollback components (such as static collision
+//! properties or mesh handles) by deferring the actual despawn until the requested frame has been
+//! confirmed. Despawned entities are instead marked with the disabling component
+//! [`RollbackDespawned`] so that they behave as though they are despawned by default.
+//!
+//! # Examples
+//! ```rust
+//! # use bevy::prelude::*;
+//! # use bevy_ggrs::{prelude::*, ResourceChecksumPlugin};
+//! #
+//! # const FPS: usize = 60;
+//! #
+//! # type MyInputType = u8;
+//! #
+//! # fn read_local_inputs() {}
+//! #
+//! # fn start(session: Session<GgrsConfig<MyInputType>>) {
+//! # let mut app = App::new();
+//! #[derive(Resource, Clone, Hash)]
+//! struct BossHealth(u32);
+//!
+//! // To include something in the checksum, it should also be rolled back
+//! app.rollback_resource_with_clone::<BossHealth>();
+//!
+//! // This will update the checksum every frame to include BossHealth
+//! app.add_plugins(ResourceChecksumPlugin::<BossHealth>::default());
+//! # }
+//! ```
+//!
+//! Entities which have been marked for despawn are disabled using the [`RollbackDespawned`]
+//! component, so they will appear as though they are despawned to normal system queries.
+
+use std::cmp::Ordering;
+use bevy::app::{App, Plugin};
+use bevy::prelude::{Children, Component, Entity, EntityCommands, EntityMut, EntityRef, EntityWorldMut, IntoScheduleConfigs, Local, Query, QueryState, Res, World};
+use ggrs::Frame;
+use crate::{AdvanceWorld, AdvanceWorldSystems, ConfirmedFrameCount, LoadWorld, LoadWorldSystems, RollbackFrameCount, SaveWorld, SaveWorldSystems};
+use crate::snapshot::despawn::private::RollbackDespawnCommandExtensionSeal;
+
+/// Marks an entity as despawned, contains the frame that the entity was despawned on.
+///
+/// When an entity is marked with this component, they MUST not be allowed to affect the simulation
+/// in any way, as they may eventually be despawned on different frames for different peers.
+/// This component is registered as "disabling" (see [ecs module docs](bevy_ecs::entity_disabling))
+/// so that the entity will not show up in queries by default.
+#[derive(Component, Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RollbackDespawned(Frame);
+
+pub struct RollbackDespawnPlugin;
+
+impl Plugin for RollbackDespawnPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_disabling_component::<RollbackDespawned>();
+
+        app.add_systems(LoadWorld, resurrect_entities.in_set(LoadWorldSystems::EntityResurrect))
+            .add_systems(AdvanceWorld, despawn_confirmed_entities.in_set(AdvanceWorldSystems::DespawnConfirmed));
+    }
+}
+
+fn resurrect_entities(
+    world: &mut World,
+    despawn_query: &mut QueryState<(Entity, &RollbackDespawned)>,
+) {
+    let rollback_frame = world.resource::<RollbackFrameCount>();
+
+    despawn_query
+        .iter(world)
+        .filter_map(|(entity, despawned_frame)| {
+            // During a world load, entities marked with the current rollback frame were marked
+            // for despawn during that frame, so we only want to resurrect entities despawned after.
+            Some(entity).filter(|_e| despawned_frame > rollback_frame)
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .for_each(|entity| { world.entity_mut(entity).remove::<RollbackDespawned>(); });
+}
+
+fn despawn_confirmed_entities(
+    world: &mut World,
+    despawn_query: &mut QueryState<(Entity, &RollbackDespawned)>,
+    mut local: Local<ConfirmedFrameCount>,
+) {
+    let confirmed_frame = world.resource::<ConfirmedFrameCount>();
+    if *confirmed_frame == *local {
+        return; // No work necessary
+    }
+    *local = *confirmed_frame;
+
+    despawn_query
+        .iter(world)
+        .filter_map(|(entity, despawned_frame)| {
+            // Entities marked as despawned on the confirmed frame or earlier can be immediately
+            // despawned.
+            Some(entity).filter(|_e| despawned_frame <= confirmed_frame)
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .for_each(|entity| { world.despawn(entity); });
+}
+
+mod private {
+    pub trait RollbackDespawnCommandExtensionSeal {}
+}
+pub trait RollbackDespawnCommandExtension: private::RollbackDespawnCommandExtensionSeal {
+    /// Despawns this entity and its children recursively using the [`RollbackDespawned`]
+    /// component, such that they can be resurrected following a rollback.
+    ///
+    /// NOTE: This does not yet support [`RelationshipTarget`] with linked spawn mode.
+    fn despawn_rollback(&mut self);
+
+    /// NOTE: Not implemented yet.
+    fn despawn_children_rollback(&mut self) -> &mut Self;
+
+    /// NOTE: Not implemented yet.
+    fn despawn_related_rollback<S>(&mut self) -> &mut Self;
+}
+
+impl RollbackDespawnCommandExtensionSeal for EntityCommands<'_> {}
+
+impl RollbackDespawnCommandExtension for EntityCommands<'_> {
+    fn despawn_rollback(&mut self) {
+        self.queue_silenced(despawn_rollback);
+    }
+
+    fn despawn_children_rollback(&mut self) -> &mut Self {
+        todo!()
+    }
+
+    fn despawn_related_rollback<S>(&mut self) -> &mut Self {
+        todo!()
+    }
+}
+
+fn despawn_rollback(mut entity: EntityWorldMut) {
+    if let Some(&RollbackFrameCount(frame)) = entity.get_resource::<RollbackFrameCount>() {
+        // If we have RollbackFrameCount we should also have ConfirmedFrameCount
+        let &ConfirmedFrameCount(confirmed) = entity.get_resource::<ConfirmedFrameCount>().unwrap();
+
+        // TODO handle wraparound
+        if confirmed < frame {
+            entity.insert_recursive::<Children>(RollbackDespawned(frame));
+            return;
+        }
+    }
+
+    // If current frame is confirmed or rollback sim is not present, we can simply despawn
+    entity.despawn();
+}
+
+macro_rules! newtype_partial_ord {
+    ($i:ident, $j:ident) => {
+        impl PartialEq<$j> for $i {
+            fn eq(&self, other: &$j) -> bool {
+                self.0 == other.0
+            }
+        }
+
+        impl PartialOrd<$j> for $i {
+            fn partial_cmp(&self, other: &$j) -> Option<Ordering> {
+                Some(self.0.cmp(&other.0))
+            }
+        }
+    };
+}
+
+newtype_partial_ord!(RollbackDespawned, RollbackFrameCount);
+newtype_partial_ord!(RollbackDespawned, ConfirmedFrameCount);

--- a/src/snapshot/despawn.rs
+++ b/src/snapshot/despawn.rs
@@ -8,31 +8,25 @@
 //! # Examples
 //! ```rust
 //! # use bevy::prelude::*;
-//! # use bevy_ggrs::{prelude::*, ResourceChecksumPlugin};
+//! # use bevy_ggrs::prelude::*;
 //! #
-//! # const FPS: usize = 60;
-//! #
-//! # type MyInputType = u8;
-//! #
-//! # fn read_local_inputs() {}
-//! #
-//! # fn start(session: Session<GgrsConfig<MyInputType>>) {
-//! # let mut app = App::new();
-//! #[derive(Resource, Clone, Hash)]
-//! struct BossHealth(u32);
-//!
-//! // To include something in the checksum, it should also be rolled back
-//! app.rollback_resource_with_clone::<BossHealth>();
-//!
-//! // This will update the checksum every frame to include BossHealth
-//! app.add_plugins(ResourceChecksumPlugin::<BossHealth>::default());
-//! # }
+//! fn despawn_player(
+//!     mut commands: Commands,
+//!     players: Query<Entity, With<Player>>,
+//! ) {
+//!     for entity in &players {
+//!         // Instead of commands.entity(entity).despawn(), use despawn_rollback()
+//!         // so the entity can be resurrected if a rollback happens.
+//!         commands.entity(entity).despawn_rollback();
+//!     }
+//! }
+//! # #[derive(Component)]
+//! # struct Player;
 //! ```
 //!
 //! Entities which have been marked for despawn are disabled using the [`RollbackDespawned`]
 //! component, so they will appear as though they are despawned to normal system queries.
 
-use crate::snapshot::despawn::private::RollbackDespawnCommandExtensionSeal;
 use crate::{
     AdvanceWorld, AdvanceWorldSystems, ConfirmedFrameCount, LoadWorld, LoadWorldSystems,
     RollbackFrameCount,
@@ -51,6 +45,10 @@ use std::cmp::Ordering;
 #[derive(Component, Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RollbackDespawned(Frame);
 
+/// Plugin that enables rollback-safe despawning via [`RollbackDespawned`].
+///
+/// Registers [`RollbackDespawned`] as a disabling component and installs the systems that
+/// resurrect entities during rollback and permanently despawn them once their frame is confirmed.
 pub struct RollbackDespawnPlugin;
 
 impl Plugin for RollbackDespawnPlugin {
@@ -113,36 +111,18 @@ fn despawn_confirmed_entities(
         });
 }
 
-mod private {
-    pub trait RollbackDespawnCommandExtensionSeal {}
-}
-pub trait RollbackDespawnCommandExtension: private::RollbackDespawnCommandExtensionSeal {
+/// Extension trait for [`EntityCommands`] that adds rollback-safe despawn methods.
+pub trait RollbackDespawnCommandExtension {
     /// Despawns this entity and its children recursively using the [`RollbackDespawned`]
     /// component, such that they can be resurrected following a rollback.
     ///
     /// NOTE: This does not yet support [`RelationshipTarget`] with linked spawn mode.
     fn despawn_rollback(&mut self);
-
-    /// NOTE: Not implemented yet.
-    fn despawn_children_rollback(&mut self) -> &mut Self;
-
-    /// NOTE: Not implemented yet.
-    fn despawn_related_rollback<S>(&mut self) -> &mut Self;
 }
-
-impl RollbackDespawnCommandExtensionSeal for EntityCommands<'_> {}
 
 impl RollbackDespawnCommandExtension for EntityCommands<'_> {
     fn despawn_rollback(&mut self) {
         self.queue_silenced(despawn_rollback);
-    }
-
-    fn despawn_children_rollback(&mut self) -> &mut Self {
-        todo!()
-    }
-
-    fn despawn_related_rollback<S>(&mut self) -> &mut Self {
-        todo!()
     }
 }
 

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -29,6 +29,7 @@ mod rollback_app;
 mod rollback_entity_map;
 mod set;
 mod strategy;
+mod despawn;
 
 pub use checksum::*;
 pub use childof_snapshot::*;
@@ -45,6 +46,7 @@ pub use rollback_app::*;
 pub use rollback_entity_map::*;
 pub use set::*;
 pub use strategy::*;
+use crate::snapshot::despawn::RollbackDespawnPlugin;
 
 pub mod prelude {
     pub use super::{Checksum, LoadWorldSystems, SaveWorldSystems};
@@ -338,6 +340,7 @@ impl Plugin for SnapshotPlugin {
                 EntitySnapshotPlugin,
                 ResourceSnapshotPlugin::<CloneStrategy<RollbackOrdered>>::default(),
                 ChildOfSnapshotPlugin,
+                RollbackDespawnPlugin,
             ));
     }
 }

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -31,7 +31,7 @@ mod rollback_entity_map;
 mod set;
 mod strategy;
 
-use crate::snapshot::despawn::RollbackDespawnPlugin;
+pub use despawn::*;
 pub use checksum::*;
 pub use childof_snapshot::*;
 pub use component_checksum::*;

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -19,6 +19,7 @@ mod childof_snapshot;
 mod component_checksum;
 mod component_map;
 mod component_snapshot;
+mod despawn;
 mod entity;
 mod entity_checksum;
 mod resource_checksum;
@@ -29,8 +30,8 @@ mod rollback_app;
 mod rollback_entity_map;
 mod set;
 mod strategy;
-mod despawn;
 
+use crate::snapshot::despawn::RollbackDespawnPlugin;
 pub use checksum::*;
 pub use childof_snapshot::*;
 pub use component_checksum::*;
@@ -46,7 +47,6 @@ pub use rollback_app::*;
 pub use rollback_entity_map::*;
 pub use set::*;
 pub use strategy::*;
-use crate::snapshot::despawn::RollbackDespawnPlugin;
 
 pub mod prelude {
     pub use super::{Checksum, LoadWorldSystems, SaveWorldSystems};

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -50,6 +50,7 @@ pub use strategy::*;
 
 pub mod prelude {
     pub use super::{Checksum, LoadWorldSystems, SaveWorldSystems};
+    pub use super::despawn::{RollbackDespawned, RollbackDespawnCommandExtension};
 }
 
 /// Label for the schedule which loads and overwrites a snapshot of the world.

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -31,12 +31,12 @@ mod rollback_entity_map;
 mod set;
 mod strategy;
 
-pub use despawn::*;
 pub use checksum::*;
 pub use childof_snapshot::*;
 pub use component_checksum::*;
 pub use component_map::*;
 pub use component_snapshot::*;
+pub use despawn::*;
 pub use entity::*;
 pub use entity_checksum::*;
 pub use resource_checksum::*;
@@ -49,8 +49,8 @@ pub use set::*;
 pub use strategy::*;
 
 pub mod prelude {
+    pub use super::despawn::{RollbackDespawnCommandExtension, RollbackDespawned};
     pub use super::{Checksum, LoadWorldSystems, SaveWorldSystems};
-    pub use super::despawn::{RollbackDespawned, RollbackDespawnCommandExtension};
 }
 
 /// Label for the schedule which loads and overwrites a snapshot of the world.

--- a/src/snapshot/set.rs
+++ b/src/snapshot/set.rs
@@ -13,6 +13,9 @@ use crate::snapshot::{AdvanceWorld, LoadWorld, SaveWorld};
 /// and [`Resource`] snapshots are loaded and applied to the [`World`].
 #[derive(SystemSet, Hash, Debug, PartialEq, Eq, Clone)]
 pub enum LoadWorldSystems {
+    /// Removes any despawn markers if the loaded frame is before they were marked.
+    /// See [`despawn module docs`](`crate::snapshot::despawn`).
+    EntityResurrect,
     /// Recreate the [`Entity`] graph as it was during the frame to be rolled back to.
     /// When this set is complete, all entities that were alive during the snapshot
     /// frame have been recreated, and any that were not have been removed. If the
@@ -68,6 +71,9 @@ pub enum AdvanceWorldSystems {
     /// Runs before [`GgrsSchedule`](`crate::GgrsSchedule`). Use this for setup work that
     /// must happen at the very start of each GGRS frame.
     First,
+    /// Despawn any entities if their marked frame has been confirmed.
+    /// See [`despawn module docs`](`crate::snapshot::despawn`).
+    DespawnConfirmed,
     /// The main GGRS frame step. [`GgrsSchedule`](`crate::GgrsSchedule`) runs here.
     Main,
     /// Runs after [`GgrsSchedule`](`crate::GgrsSchedule`). Use this for teardown or
@@ -86,6 +92,7 @@ impl Plugin for SnapshotSetPlugin {
         app.configure_sets(
             LoadWorld,
             (
+                LoadWorldSystems::EntityResurrect,
                 LoadWorldSystems::Entity,
                 LoadWorldSystems::EntityFlush,
                 LoadWorldSystems::Data,
@@ -96,12 +103,16 @@ impl Plugin for SnapshotSetPlugin {
         )
         .configure_sets(
             SaveWorld,
-            (SaveWorldSystems::Checksum, SaveWorldSystems::Snapshot).chain(),
+            (
+                SaveWorldSystems::Checksum,
+                SaveWorldSystems::Snapshot
+            ).chain(),
         )
         .configure_sets(
             AdvanceWorld,
             (
                 AdvanceWorldSystems::First,
+                AdvanceWorldSystems::DespawnConfirmed,
                 AdvanceWorldSystems::Main,
                 AdvanceWorldSystems::Last,
             )

--- a/src/snapshot/set.rs
+++ b/src/snapshot/set.rs
@@ -103,10 +103,7 @@ impl Plugin for SnapshotSetPlugin {
         )
         .configure_sets(
             SaveWorld,
-            (
-                SaveWorldSystems::Checksum,
-                SaveWorldSystems::Snapshot
-            ).chain(),
+            (SaveWorldSystems::Checksum, SaveWorldSystems::Snapshot).chain(),
         )
         .configure_sets(
             AdvanceWorld,


### PR DESCRIPTION
This PR implements a new way of despawning entities using a disabling component that records which frame the entity was despawned on. If the simulation performs a rollback then we can simply remove the component to resurrect the entity. If instead, the confirmed frame count moves past the despawn marker, then we can safely full despawn the entity.

This is a first pass at an implemention to support further discussion, with a couple of intended features missing. It has not been tested yet.

I haven't yet looked into which other systems are going to need to build in explicit bypass for the disabling component, but my theory is that existing systems will continue to work fine. Because we resurrect the entities at the start of `LoadWorld`, the existing mechanism for respawning entities that are present in the snapshot but don't exist in the world should simply see that the resurrected entities are there, as though they never despawned.

Looking for comments/feedback on the approach and any steer on what can be accepted as a PR down the line.