### PR TITLE
Rollback marker

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -53,7 +53,7 @@ fn foo_1000(c: &mut Criterion) {
     app.world_mut()
         .run_system_once(|mut commands: Commands| {
             for i in 0..1000 {
-                commands.spawn(Foo(i)).add_rollback();
+                commands.spawn((Foo(i), Rollback));
             }
         })
         .unwrap();
@@ -79,9 +79,9 @@ fn foo_bar_baz_1000(c: &mut Criterion) {
     app.world_mut()
         .run_system_once(|mut commands: Commands| {
             for i in 0..1000 {
-                commands.spawn(Foo(i)).add_rollback();
-                commands.spawn(Bar(i)).add_rollback();
-                commands.spawn(Baz(i)).add_rollback();
+                commands.spawn((Foo(i), Rollback));
+                commands.spawn((Bar(i), Rollback));
+                commands.spawn((Baz(i), Rollback));
             }
         })
         .unwrap();

--- a/examples/box_game/box_game.rs
+++ b/examples/box_game/box_game.rs
@@ -1,8 +1,5 @@
 use bevy::{platform::collections::HashMap, prelude::*};
-use bevy_ggrs::{
-    AddRollbackCommandExtension, GgrsConfig, LocalInputs, LocalPlayers, PlayerInputs, Rollback,
-    Session,
-};
+use bevy_ggrs::{GgrsConfig, LocalInputs, LocalPlayers, PlayerInputs, Rollback, Session};
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
@@ -114,20 +111,18 @@ pub fn setup_system(
         let color = PLAYER_COLORS[handle % PLAYER_COLORS.len()];
 
         // Entities which will be rolled back can be created just like any other...
-        commands
-            .spawn((
-                // ...add visual information...
-                Mesh3d(mesh.clone()),
-                MeshMaterial3d(materials.add(StandardMaterial::from(color))),
-                transform,
-                // ...flags...
-                Player { handle },
-                // ...and components which will be rolled-back...
-                Velocity::default(),
-            ))
-            // ...just ensure you call `add_rollback()`
-            // This ensures a stable ID is available for the rollback system to refer to
-            .add_rollback();
+        commands.spawn((
+            // ...add visual information...
+            Mesh3d(mesh.clone()),
+            MeshMaterial3d(materials.add(StandardMaterial::from(color))),
+            transform,
+            // ...flags...
+            Player { handle },
+            // ...and components which will be rolled-back...
+            Velocity::default(),
+            // The Rollback marker ensures a stable ID is available for the rollback system
+            Rollback,
+        ));
     }
 
     // light
@@ -153,7 +148,6 @@ pub fn increase_frame_system(mut frame_count: ResMut<FrameCount>) {
 #[allow(dead_code)]
 pub fn move_cube_system(
     mut query: Query<(&mut Transform, &mut Velocity, &Player), With<Rollback>>,
-    //                                                              ^------^ Added by `add_rollback` earlier
     inputs: Res<PlayerInputs<BoxConfig>>,
     // Thanks to RollbackTimePlugin, this is rollback safe
     time: Res<Time>,

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -257,13 +257,12 @@ fn spawn_particles(mut commands: Commands, args: Res<Args>, mut rng: ResMut<Part
     let ttl = args.fps * 5;
 
     for _ in 0..args.rate {
-        commands
-            .spawn((
-                Sprite::from_color(ORANGE, Vec2::splat(5.0)),
-                Velocity(vec3(rng.random_range(-s..s), rng.random_range(-s..s), 0.0)),
-                Ttl(ttl),
-            ))
-            .add_rollback();
+        commands.spawn((
+            Sprite::from_color(ORANGE, Vec2::splat(5.0)),
+            Velocity(vec3(rng.random_range(-s..s), rng.random_range(-s..s), 0.0)),
+            Ttl(ttl),
+            Rollback,
+        ));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ pub(crate) mod time;
 
 pub mod prelude {
     pub use crate::{
-        AddRollbackCommandExtension, GgrsConfig, GgrsPlugin, GgrsSchedule, GgrsTime, PlayerInputs,
-        ReadInputs, Rollback, RollbackApp, RollbackFrameRate, Session, SyncTestMismatch,
+        GgrsConfig, GgrsPlugin, GgrsSchedule, GgrsTime, PlayerInputs, ReadInputs, Rollback,
+        RollbackApp, RollbackFrameRate, RollbackId, Session, SyncTestMismatch,
         snapshot::prelude::*,
     };
     pub use ggrs::{GgrsEvent, PlayerType, SessionBuilder};

--- a/src/snapshot/component_checksum.rs
+++ b/src/snapshot/component_checksum.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use bevy::prelude::*;
 
 use crate::{
-    ChecksumFlag, ChecksumPart, Rollback, RollbackOrdered, SaveWorld, SaveWorldSystems,
+    ChecksumFlag, ChecksumPart, RollbackId, RollbackOrdered, SaveWorld, SaveWorldSystems,
     checksum_hasher,
 };
 
@@ -60,12 +60,12 @@ where
         let update = move |mut commands: Commands,
                            rollback_ordered: Res<RollbackOrdered>,
                            components: Query<
-            (&Rollback, &C),
-            (With<Rollback>, Without<ChecksumFlag<C>>),
+            (&RollbackId, &C),
+            (With<RollbackId>, Without<ChecksumFlag<C>>),
         >,
                            mut checksum: Query<
             &mut ChecksumPart,
-            (Without<Rollback>, With<ChecksumFlag<C>>),
+            (Without<RollbackId>, With<ChecksumFlag<C>>),
         >| {
             let mut hasher = checksum_hasher();
 

--- a/src/snapshot/component_map.rs
+++ b/src/snapshot/component_map.rs
@@ -94,7 +94,7 @@ where
 mod tests {
     use super::*;
     use crate::snapshot::{
-        AddRollbackCommandExtension, AdvanceWorld, RollbackApp, SnapshotPlugin,
+        AdvanceWorld, Rollback, RollbackApp, SnapshotPlugin,
         tests::{advance_frame, load_world, save_world},
     };
     use bevy::log::LogPlugin;
@@ -111,9 +111,11 @@ mod tests {
     struct Likes(#[entities] Entity);
 
     #[derive(Component, Clone, Copy)]
+    #[require(Rollback)]
     struct Friend;
 
     #[derive(Component)]
+    #[require(Rollback)]
     struct Player;
 
     fn like_single_friend(
@@ -132,7 +134,7 @@ mod tests {
 
     fn spawn_friend(mut commands: Commands, inputs: Res<Input>) {
         if let Input::SpawnFriend = *inputs {
-            commands.spawn(Friend).add_rollback();
+            commands.spawn(Friend);
         }
     }
 
@@ -149,7 +151,7 @@ mod tests {
     }
 
     fn spawn_player(mut commands: Commands) {
-        commands.spawn(Player).add_rollback();
+        commands.spawn(Player);
     }
 
     #[test]

--- a/src/snapshot/component_snapshot.rs
+++ b/src/snapshot/component_snapshot.rs
@@ -1,6 +1,6 @@
 use crate::{
-    GgrsComponentSnapshot, GgrsComponentSnapshots, LoadWorld, LoadWorldSystems, Rollback,
-    RollbackFrameCount, SaveWorld, SaveWorldSystems, Strategy,
+    GgrsComponentSnapshot, GgrsComponentSnapshots, LoadWorld, LoadWorldSystems, RollbackFrameCount,
+    RollbackId, SaveWorld, SaveWorldSystems, Strategy,
 };
 use bevy::{
     ecs::component::{Immutable, Mutable},
@@ -58,7 +58,7 @@ where
     pub fn save(
         mut snapshots: ResMut<GgrsComponentSnapshots<S::Target, S::Stored>>,
         frame: Res<RollbackFrameCount>,
-        query: Query<(&Rollback, &S::Target)>,
+        query: Query<(&RollbackId, &S::Target)>,
     ) {
         let components = query
             .iter()
@@ -86,7 +86,7 @@ where
         mut commands: Commands,
         mut snapshots: ResMut<GgrsComponentSnapshots<S::Target, S::Stored>>,
         frame: Res<RollbackFrameCount>,
-        mut query: Query<(Entity, &Rollback, Option<&mut S::Target>)>,
+        mut query: Query<(Entity, &RollbackId, Option<&mut S::Target>)>,
     ) {
         let snapshot = snapshots.rollback(frame.0).get();
 
@@ -203,7 +203,7 @@ where
         mut commands: Commands,
         mut snapshots: ResMut<GgrsComponentSnapshots<S::Target, S::Stored>>,
         frame: Res<RollbackFrameCount>,
-        mut query: Query<(Entity, &Rollback, Has<S::Target>)>,
+        mut query: Query<(Entity, &RollbackId, Has<S::Target>)>,
     ) {
         let snapshot = snapshots.rollback(frame.0).get();
 

--- a/src/snapshot/entity.rs
+++ b/src/snapshot/entity.rs
@@ -1,6 +1,6 @@
 use crate::{
     GgrsComponentSnapshot, GgrsComponentSnapshots, LoadWorld, LoadWorldSystems, Rollback,
-    RollbackEntityMap, RollbackFrameCount, SaveWorld, SaveWorldSystems,
+    RollbackEntityMap, RollbackFrameCount, RollbackId, SaveWorld, SaveWorldSystems,
 };
 use bevy::{platform::collections::HashMap, prelude::*};
 
@@ -31,7 +31,7 @@ impl EntitySnapshotPlugin {
     pub fn save(
         mut snapshots: ResMut<GgrsComponentSnapshots<Entity>>,
         frame: Res<RollbackFrameCount>,
-        query: Query<(&Rollback, Entity)>,
+        query: Query<(&RollbackId, Entity)>,
     ) {
         let entities = query.iter().map(|(&rollback, entity)| (rollback, entity));
 
@@ -47,7 +47,7 @@ impl EntitySnapshotPlugin {
         mut snapshots: ResMut<GgrsComponentSnapshots<Entity>>,
         mut map: ResMut<RollbackEntityMap>,
         frame: Res<RollbackFrameCount>,
-        query: Query<(&Rollback, Entity)>,
+        query: Query<(&RollbackId, Entity)>,
     ) {
         let mut entity_map = HashMap::default();
         let mut rollback_mapping = HashMap::new();
@@ -71,7 +71,7 @@ impl EntitySnapshotPlugin {
                     commands.entity(current_entity).despawn();
                 }
                 (None, Some(old_entity)) => {
-                    let current_entity = commands.spawn(rollback).id();
+                    let current_entity = commands.spawn((rollback, Rollback)).id();
                     entity_map.insert(old_entity, current_entity);
                 }
                 (None, None) => unreachable!(

--- a/src/snapshot/entity_checksum.rs
+++ b/src/snapshot/entity_checksum.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use bevy::prelude::*;
 
 use crate::{
-    ChecksumFlag, ChecksumPart, Rollback, RollbackOrdered, SaveWorld, SaveWorldSystems,
+    ChecksumFlag, ChecksumPart, RollbackId, RollbackOrdered, SaveWorld, SaveWorldSystems,
     checksum_hasher,
 };
 
@@ -14,8 +14,8 @@ impl EntityChecksumPlugin {
     pub fn update(
         mut commands: Commands,
         rollback_ordered: Res<RollbackOrdered>,
-        active_entities: Query<&Rollback, (With<Rollback>, Without<ChecksumFlag<Entity>>)>,
-        mut checksum: Query<&mut ChecksumPart, (Without<Rollback>, With<ChecksumFlag<Entity>>)>,
+        active_entities: Query<&RollbackId, (With<RollbackId>, Without<ChecksumFlag<Entity>>)>,
+        mut checksum: Query<&mut ChecksumPart, (Without<RollbackId>, With<ChecksumFlag<Entity>>)>,
     ) {
         let mut hasher = checksum_hasher();
 

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -239,7 +239,7 @@ impl<For, As> GgrsSnapshots<For, As> {
 
 /// A storage type suitable for per-[`Entity`] snapshots, such as [`Component`] types.
 pub struct GgrsComponentSnapshot<For, As = For> {
-    snapshot: HashMap<Rollback, As>,
+    snapshot: HashMap<RollbackId, As>,
     _phantom: PhantomData<For>,
 }
 
@@ -254,7 +254,7 @@ impl<For, As> Default for GgrsComponentSnapshot<For, As> {
 
 impl<For, As> GgrsComponentSnapshot<For, As> {
     /// Create a new snapshot from a list of [`Rollback`] flags and stored [`Component`] types.
-    pub fn new(components: impl IntoIterator<Item = (Rollback, As)>) -> Self {
+    pub fn new(components: impl IntoIterator<Item = (RollbackId, As)>) -> Self {
         Self {
             snapshot: components.into_iter().collect(),
             ..default()
@@ -262,18 +262,18 @@ impl<For, As> GgrsComponentSnapshot<For, As> {
     }
 
     /// Insert a single snapshot for the provided [`Rollback`].
-    pub fn insert(&mut self, entity: Rollback, snapshot: As) -> &mut Self {
+    pub fn insert(&mut self, entity: RollbackId, snapshot: As) -> &mut Self {
         self.snapshot.insert(entity, snapshot);
         self
     }
 
     /// Get a single snapshot for the provided [`Rollback`].
-    pub fn get(&self, entity: &Rollback) -> Option<&As> {
+    pub fn get(&self, entity: &RollbackId) -> Option<&As> {
         self.snapshot.get(entity)
     }
 
     /// Iterate over all stored snapshots.
-    pub fn iter(&self) -> impl Iterator<Item = (&Rollback, &As)> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = (&RollbackId, &As)> + '_ {
         self.snapshot.iter()
     }
 }

--- a/src/snapshot/resource_checksum.rs
+++ b/src/snapshot/resource_checksum.rs
@@ -2,7 +2,7 @@ use std::hash::{Hash, Hasher};
 
 use bevy::prelude::*;
 
-use crate::{ChecksumFlag, ChecksumPart, Rollback, SaveWorld, SaveWorldSystems, checksum_hasher};
+use crate::{ChecksumFlag, ChecksumPart, RollbackId, SaveWorld, SaveWorldSystems, checksum_hasher};
 
 /// Plugin which will track the [`Resource`] `R` and ensure a [`ChecksumPart`] is
 /// available and updated. This can be used to generate a [`Checksum`](`crate::Checksum`).
@@ -58,7 +58,7 @@ where
                            resource: Res<R>,
                            mut checksum: Query<
             &mut ChecksumPart,
-            (Without<Rollback>, With<ChecksumFlag<R>>),
+            (Without<RollbackId>, With<ChecksumFlag<R>>),
         >| {
             let result = ChecksumPart(custom_hasher(resource.as_ref()) as u128);
 

--- a/src/snapshot/rollback_app.rs
+++ b/src/snapshot/rollback_app.rs
@@ -112,6 +112,12 @@ pub trait RollbackApp {
     fn checksum_resource<Type>(&mut self, hasher: for<'a> fn(&'a Type) -> u64) -> &mut Self
     where
         Type: Resource;
+
+    /// Registers [`Rollback`](`super::Rollback`) as a required component for `Type`.
+    /// This is useful for third-party components where you can't add `#[require(Rollback)]`.
+    fn require_rollback<Type>(&mut self) -> &mut Self
+    where
+        Type: Component;
 }
 
 impl RollbackApp for App {
@@ -218,5 +224,13 @@ impl RollbackApp for App {
         Type: Resource,
     {
         self.add_plugins(ResourceChecksumPlugin::<Type>(hasher))
+    }
+
+    fn require_rollback<Type>(&mut self) -> &mut Self
+    where
+        Type: Component,
+    {
+        self.register_required_components::<Type, super::Rollback>();
+        self
     }
 }

--- a/tests/hierarchy.rs
+++ b/tests/hierarchy.rs
@@ -33,10 +33,9 @@ fn input_system(
 
 fn setup_system(mut commands: Commands) {
     commands
-        .spawn(ParentEntity)
-        .add_rollback()
+        .spawn((ParentEntity, Rollback))
         .with_children(|parent| {
-            parent.spawn(ChildEntity).add_rollback();
+            parent.spawn((ChildEntity, Rollback));
         });
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -9,8 +9,8 @@ use bevy::{
     time::TimeUpdateStrategy,
 };
 use bevy_ggrs::{
-    AddRollbackCommandExtension, GgrsConfig, GgrsPlugin, GgrsSchedule, LocalInputs, LocalPlayers,
-    PlayerInputs, ReadInputs, Rollback, Session,
+    GgrsConfig, GgrsPlugin, GgrsSchedule, LocalInputs, LocalPlayers, PlayerInputs, ReadInputs,
+    Rollback, RollbackId, Session,
 };
 use core::time::Duration;
 use ggrs::{Config, P2PSession, PlayerHandle, PlayerType, SessionBuilder, UdpNonBlockingSocket};
@@ -192,7 +192,7 @@ pub struct Velocity {
 }
 
 pub fn move_player_system(
-    mut query: Query<(&mut Transform, &mut Velocity, &PlayerComponent), With<Rollback>>,
+    mut query: Query<(&mut Transform, &mut Velocity, &PlayerComponent), With<RollbackId>>,
     inputs: Res<PlayerInputs<TestConfig>>,
 ) {
     const MOVEMENT_SPEED: f32 = 0.1;
@@ -213,12 +213,11 @@ pub fn spawn_players(mut commands: Commands, session: Res<Session<TestConfig>>) 
     };
 
     for handle in 0..num_players {
-        commands
-            .spawn((
-                PlayerComponent { handle },
-                Velocity::default(),
-                Transform::default(),
-            ))
-            .add_rollback();
+        commands.spawn((
+            PlayerComponent { handle },
+            Velocity::default(),
+            Transform::default(),
+            Rollback,
+        ));
     }
 }


### PR DESCRIPTION
This effectively renames the old Rollback to RollbackId, and creates a
new unit struct `Rollback`

So the new flow is:

1. Insert `Rollback` on an entity in any way you want (required
   components, scenes, spawning.
2. The `OnAdd` hook handles creating a `RollbackId(Entity)` which is
   what we use internally for ordering entities.

This had the added overhead of having two components per rollback
entity. So a redundant entity list basically. But it allows much better
ergonomics, and scene authoring workflows, scripting interations++.

Before:

```rust
#[derive(Component)
struct Player;

// Have to remember to explicitly add rollback anywhere Player is spawned
commands.spawn((Player, Sprite {}).add_rollback();
```

Now:

```rust
#[derive(Component)
#[require(Rollback)
struct Player;

// Rollback added automatically :)
commands.spawn((Player, Sprite {});
```

Or simply:

```rust
app.register_required_components::<RigidBody, Rollback>();
```

or

```rust
app.require_rollback::<RigidBody>(); 
```

Then all movable physics objects will be rolled back. Don't have to remember to add rollback anywhere.

If you prefer to be explicit about it, you could still do:

```rust
commands.spawn((Player, Rollback, Sprite {}));
```