### PR TITLE
Fix GgrsTime panic on session restart

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -72,7 +72,17 @@ impl GgrsTimePlugin {
         // By scaling to nanoseconds, rounding error should be minimised.
         let runtime = Duration::from_nanos(this_frame * 1_000_000_000 / framerate);
 
-        time.advance_to(runtime);
+        // `GgrsTime` is fully derived from the frame count, so it must be able to
+        // follow the frame count backwards. For example, when a session is stopped
+        // and a new one started, the frame count resets to 0 while this clock still
+        // holds the previous session's elapsed time. `advance_to` panics on backward
+        // movement, so reconstruct the clock in that case instead.
+        if runtime >= time.elapsed() {
+            time.advance_to(runtime);
+        } else {
+            *time = Time::new_with(GgrsTime);
+            time.advance_by(runtime);
+        }
     }
 
     /// Overrides the [default time](`Time<()>`) with [`Time<GgrsTime>`].

--- a/src/time.rs
+++ b/src/time.rs
@@ -75,13 +75,14 @@ impl GgrsTimePlugin {
         // `GgrsTime` is fully derived from the frame count, so it must be able to
         // follow the frame count backwards. For example, when a session is stopped
         // and a new one started, the frame count resets to 0 while this clock still
-        // holds the previous session's elapsed time. `advance_to` panics on backward
-        // movement, so reconstruct the clock in that case instead.
-        if runtime >= time.elapsed() {
-            time.advance_to(runtime);
-        } else {
+        // holds the previous session's elapsed time.
+        let time_moved_backwards = runtime < time.elapsed();
+        if time_moved_backwards {
+            // `advance_to` panics on backward movement, so rebuild the clock from zero.
             *time = Time::new_with(GgrsTime);
             time.advance_by(runtime);
+        } else {
+            time.advance_to(runtime);
         }
     }
 

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -1,0 +1,49 @@
+#[allow(dead_code)]
+mod common;
+
+use bevy::prelude::*;
+use bevy_ggrs::{RollbackFrameCount, prelude::*};
+use common::{GgrsConfig, base_synctest_app, synctest_session};
+use core::time::Duration;
+
+/// Restarting a session after frames have elapsed must not panic.
+///
+/// `Time<GgrsTime>` is derived from `RollbackFrameCount`. When a session is
+/// stopped and a new one started, the frame count resets to 0 while the clock
+/// still holds the previous session's elapsed time. The clock must follow the
+/// frame count backward instead of panicking inside `Time::advance_to`.
+///
+/// Regression test for the session-restart panic.
+#[test]
+fn ggrs_time_survives_session_restart() {
+    let mut app = base_synctest_app(2);
+
+    // Advance the first session so GgrsTime accumulates elapsed time.
+    for _ in 0..30 {
+        app.update();
+    }
+    assert!(
+        app.world().resource::<Time<GgrsTime>>().elapsed() > Duration::ZERO,
+        "GgrsTime should have advanced during the first session"
+    );
+
+    // Stop the session; the next tick runs bevy_ggrs's no-session branch,
+    // which resets RollbackFrameCount to 0 while leaving GgrsTime stale.
+    app.world_mut().remove_resource::<Session<GgrsConfig>>();
+    app.update();
+
+    // Start a fresh session at frame 0 and advance. This previously panicked
+    // because GgrsTime's elapsed was ahead of the new frame's runtime.
+    app.world_mut().insert_resource(synctest_session(2));
+    app.update();
+
+    // The clock reflects the restarted session's (low) frame count, not the
+    // stale value from before the restart.
+    let frame = app.world().resource::<RollbackFrameCount>().0;
+    let expected = Duration::from_nanos(frame as u64 * 1_000_000_000 / 60);
+    assert_eq!(
+        app.world().resource::<Time<GgrsTime>>().elapsed(),
+        expected,
+        "GgrsTime should track the restarted session's frame count"
+    );
+}


### PR DESCRIPTION
`update()` called `advance_to()` unconditionally, which panics when the frame count moves backwards (e.g. stopping a session and starting a new one at frame 0). Reconstruct the derived clock instead when runtime is behind elapsed. Adds a regression test.