### PR TITLE
Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["network-programming", "game-development"]
 wasm-bindgen = ["instant/wasm-bindgen", "ggrs/wasm-bindgen"]
 
 [dependencies]
-bevy = { version = "0.18.0", default-features = false, features = ["bevy_log"] }
+bevy = { version = "0.19", default-features = false, features = ["bevy_log"] }
 instant = { version = "0.1", optional = true }
 log = "0.4"
 #ggrs = { version = "0.12.0", features = ["sync-send"] }
@@ -26,7 +26,7 @@ disqualified = "1.0.0"
 serde = { version = "1", default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.18", default-features = true }
+bevy = { version = "0.19", default-features = true }
 clap = { version = "4.4", features = ["derive"] }
 rand = "0.9"
 rand_xoshiro = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ serde = { version = "1", default-features = false }
 [dev-dependencies]
 bevy = { version = "0.19", default-features = true }
 clap = { version = "4.4", features = ["derive"] }
-rand = "0.9"
-rand_xoshiro = "0.7"
+rand = "0.10"
+rand_xoshiro = "0.8"
 serde = "1.0.196"
 serde_json = "1.0"
 serial_test = "3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ rand = "0.9"
 rand_xoshiro = "0.7"
 serde = "1.0.196"
 serde_json = "1.0"
-serial_test = "2.0"
-criterion = "0.5"
+serial_test = "3.5"
+criterion = "0.8"
 
 # Examples
 [[example]]

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -5,7 +5,7 @@ use bevy::{
 use bevy_ggrs::{LocalInputs, LocalPlayers, checksum_hasher, prelude::*};
 use clap::Parser;
 use ggrs::{DesyncDetection, UdpNonBlockingSocket};
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use std::{
     hash::{Hash, Hasher},
     net::SocketAddr,

--- a/examples/stress_tests/particles.rs
+++ b/examples/stress_tests/particles.rs
@@ -124,7 +124,7 @@ struct Ttl(usize);
 
 type GameRng = rand_xoshiro::Xoshiro256PlusPlus;
 
-#[derive(Resource, Component, Clone, Deref, DerefMut)]
+#[derive(Resource, Clone, Deref, DerefMut)]
 struct ParticleRng(GameRng);
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,9 @@
 #![allow(clippy::type_complexity)] // Suppress warnings around Query
 
 use bevy::ecs::intern::Interned;
+use bevy::ecs::schedule::SingleThreadedExecutor;
 use bevy::{
-    ecs::schedule::{ExecutorKind, LogLevel, ScheduleBuildSettings, ScheduleLabel},
+    ecs::schedule::{LogLevel, ScheduleBuildSettings, ScheduleLabel},
     input::InputSystems,
     platform::collections::HashMap,
     prelude::*,
@@ -233,9 +234,9 @@ impl<C: Config> Plugin for GgrsPlugin<C> {
             .init_resource::<FixedTimestepData>()
             .init_schedule(ReadInputs)
             .edit_schedule(AdvanceWorld, |schedule| {
-                // AdvanceWorld is mostly a facilitator for GgrsSchedule, so SingleThreaded avoids overhead
+                // AdvanceWorld is mostly a facilitator for GgrsSchedule, so single threading avoids overhead
                 // This can be overridden if desired.
-                schedule.set_executor_kind(ExecutorKind::SingleThreaded);
+                schedule.set_executor(SingleThreadedExecutor::new());
             })
             .edit_schedule(GgrsSchedule, |schedule| {
                 schedule.set_build_settings(ScheduleBuildSettings {

--- a/src/snapshot/resource_map.rs
+++ b/src/snapshot/resource_map.rs
@@ -6,7 +6,10 @@
 
 use std::marker::PhantomData;
 
-use bevy::{ecs::entity::MapEntities, prelude::*};
+use bevy::{
+    ecs::{component::Mutable, entity::MapEntities},
+    prelude::*,
+};
 
 use crate::{LoadWorld, LoadWorldSystems, RollbackEntityMap};
 
@@ -43,14 +46,14 @@ use crate::{LoadWorld, LoadWorldSystems, RollbackEntityMap};
 /// ```
 pub struct ResourceMapEntitiesPlugin<R>
 where
-    R: Resource + MapEntities,
+    R: Resource<Mutability = Mutable> + MapEntities,
 {
     _phantom: PhantomData<R>,
 }
 
 impl<R> Default for ResourceMapEntitiesPlugin<R>
 where
-    R: Resource + MapEntities,
+    R: Resource<Mutability = Mutable> + MapEntities,
 {
     fn default() -> Self {
         Self {
@@ -61,7 +64,7 @@ where
 
 impl<R> ResourceMapEntitiesPlugin<R>
 where
-    R: Resource + MapEntities,
+    R: Resource<Mutability = Mutable> + MapEntities,
 {
     /// Exclusive system which will apply a [`RollbackEntityMap`] to the [`Resource`] `R`, provided it implements [`MapEntities`].
     pub fn update(world: &mut World) {
@@ -73,7 +76,7 @@ where
 
 fn apply_rollback_map_to_resource_inner<R>(world: &mut World, map: Mut<RollbackEntityMap>)
 where
-    R: Resource + MapEntities,
+    R: Resource<Mutability = Mutable> + MapEntities,
 {
     if let Some(mut resource) = world.get_resource_mut::<R>() {
         resource.map_entities(&mut map.as_ref());
@@ -84,7 +87,7 @@ where
 
 impl<R> Plugin for ResourceMapEntitiesPlugin<R>
 where
-    R: Resource + MapEntities,
+    R: Resource<Mutability = Mutable> + MapEntities,
 {
     /// Registers the entity-mapping system for this resource type in [`LoadWorldSystems::Mapping`].
     fn build(&self, app: &mut App) {

--- a/src/snapshot/resource_snapshot.rs
+++ b/src/snapshot/resource_snapshot.rs
@@ -3,11 +3,16 @@
 //! [`ResourceSnapshotPlugin`] saves a copy of a resource each frame (using a configurable
 //! [`Strategy`]) and restores it during rollback. Resources that are absent from the world
 //! are snapshotted as `None` and removed on restore.
+//!
+//! Note: only mutable resources are supported (Bevy 0.19's default). Immutable resources
+//! (`Mutability = Immutable`) would need a separate restore path that removes and re-inserts
+//! rather than updating in place; that is left as future work.
 
 use crate::{
     GgrsResourceSnapshots, LoadWorld, LoadWorldSystems, RollbackFrameCount, SaveWorld,
     SaveWorldSystems, Strategy,
 };
+use bevy::ecs::component::Mutable;
 use bevy::prelude::*;
 use std::marker::PhantomData;
 
@@ -36,7 +41,7 @@ use std::marker::PhantomData;
 pub struct ResourceSnapshotPlugin<S>
 where
     S: Strategy,
-    S::Target: Resource,
+    S::Target: Resource<Mutability = Mutable>,
     S::Stored: Send + Sync + 'static,
 {
     _phantom: PhantomData<S>,
@@ -45,7 +50,7 @@ where
 impl<S> Default for ResourceSnapshotPlugin<S>
 where
     S: Strategy,
-    S::Target: Resource,
+    S::Target: Resource<Mutability = Mutable>,
     S::Stored: Send + Sync + 'static,
 {
     fn default() -> Self {
@@ -58,7 +63,7 @@ where
 impl<S> ResourceSnapshotPlugin<S>
 where
     S: Strategy,
-    S::Target: Resource,
+    S::Target: Resource<Mutability = Mutable>,
     S::Stored: Send + Sync + 'static,
 {
     /// System that snapshots the resource for this frame. Stores `None` if the resource is absent.
@@ -96,7 +101,7 @@ where
 impl<S> Plugin for ResourceSnapshotPlugin<S>
 where
     S: Send + Sync + 'static + Strategy,
-    S::Target: Resource,
+    S::Target: Resource<Mutability = Mutable>,
     S::Stored: Send + Sync + 'static,
 {
     /// Registers snapshot storage and the save/load systems for this resource type.

--- a/src/snapshot/rollback_app.rs
+++ b/src/snapshot/rollback_app.rs
@@ -45,7 +45,7 @@ pub trait RollbackApp {
     /// uses [`Copy`] based snapshots for rollback.
     fn rollback_resource_with_copy<Type>(&mut self) -> &mut Self
     where
-        Type: Resource + Copy;
+        Type: Resource<Mutability = Mutable> + Copy;
 
     /// Registers a component type for saving and loading from the world. This
     /// uses [`Clone`] based snapshots for rollback.
@@ -63,7 +63,7 @@ pub trait RollbackApp {
     /// uses [`Clone`] based snapshots for rollback.
     fn rollback_resource_with_clone<Type>(&mut self) -> &mut Self
     where
-        Type: Resource + Clone;
+        Type: Resource<Mutability = Mutable> + Clone;
 
     /// Registers a component type for saving and loading from the world. This
     /// uses [`reflection`](`Reflect`) based snapshots for rollback.
@@ -93,7 +93,7 @@ pub trait RollbackApp {
     /// If you require this behavior, see [`ComponentMapEntitiesPlugin`].
     fn rollback_resource_with_reflect<Type>(&mut self) -> &mut Self
     where
-        Type: Resource + Reflect + FromWorld;
+        Type: Resource<Mutability = Mutable> + Reflect + FromWorld;
 
     /// Adds a component type to the checksum generation pipeline using [`Hash`].
     fn checksum_component_with_hash<Type>(&mut self) -> &mut Self
@@ -113,7 +113,7 @@ pub trait RollbackApp {
     /// Updates a resource after rollback using [`MapEntities`].
     fn update_resource_with_map_entities<Type>(&mut self) -> &mut Self
     where
-        Type: Resource + MapEntities;
+        Type: Resource<Mutability = Mutable> + MapEntities;
 
     /// Adds a component type to the checksum generation pipeline.
     fn checksum_component<Type>(&mut self, hasher: for<'a> fn(&'a Type) -> u64) -> &mut Self
@@ -149,7 +149,7 @@ impl RollbackApp for App {
 
     fn rollback_resource_with_reflect<Type>(&mut self) -> &mut Self
     where
-        Type: Resource + Reflect + FromWorld,
+        Type: Resource<Mutability = Mutable> + Reflect + FromWorld,
     {
         self.add_plugins(ResourceSnapshotPlugin::<ReflectStrategy<Type>>::default())
     }
@@ -170,7 +170,7 @@ impl RollbackApp for App {
 
     fn rollback_resource_with_copy<Type>(&mut self) -> &mut Self
     where
-        Type: Resource + Copy,
+        Type: Resource<Mutability = Mutable> + Copy,
     {
         self.add_plugins(ResourceSnapshotPlugin::<CopyStrategy<Type>>::default())
     }
@@ -191,7 +191,7 @@ impl RollbackApp for App {
 
     fn rollback_resource_with_clone<Type>(&mut self) -> &mut Self
     where
-        Type: Resource + Clone,
+        Type: Resource<Mutability = Mutable> + Clone,
     {
         self.add_plugins(ResourceSnapshotPlugin::<CloneStrategy<Type>>::default())
     }
@@ -219,7 +219,7 @@ impl RollbackApp for App {
 
     fn update_resource_with_map_entities<Type>(&mut self) -> &mut Self
     where
-        Type: Resource + MapEntities,
+        Type: Resource<Mutability = Mutable> + MapEntities,
     {
         self.add_plugins(ResourceMapEntitiesPlugin::<Type>::default())
     }


### PR DESCRIPTION
Relatively straightforward and simple port to 0.19.

I also tried to unify the resource vs component paths. E.g. ComponentSnapshotPlugin vs. ResourceSnapshotPlugin, since Resources are now just regular Components internally... However I ran into issues about how to mark them for rollback or not. On entities we add a RollbackId, but on resources? We would need to have observers or something and it could get messy. Maybe it's possible, but in any case I think a simple port is a good starting point.

Confirmed box_test_p2p was working on localhost