### PR TITLE
Expose GGRS frame timing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ pub(crate) mod time;
 /// Convenient re-exports of the most commonly used types. Glob-import this to get started.
 pub mod prelude {
     pub use crate::{
-        GgrsConfig, GgrsPlugin, GgrsSchedule, GgrsTime, PlayerInputs, ReadInputs, Rollback,
-        RollbackApp, RollbackFrameRate, RollbackId, Session, SyncTestMismatch,
+        GgrsConfig, GgrsFrameTiming, GgrsPlugin, GgrsSchedule, GgrsTime, PlayerInputs, ReadInputs,
+        Rollback, RollbackApp, RollbackFrameRate, RollbackId, Session, SyncTestMismatch,
         snapshot::prelude::*,
     };
     pub use ggrs::{GgrsEvent, PlayerType, SessionBuilder};
@@ -232,6 +232,7 @@ impl<C: Config> Plugin for GgrsPlugin<C> {
             .init_resource::<MaxPredictionWindow>()
             .init_resource::<LocalPlayers>()
             .init_resource::<FixedTimestepData>()
+            .init_resource::<GgrsFrameTiming>()
             .init_schedule(ReadInputs)
             .edit_schedule(AdvanceWorld, |schedule| {
                 // AdvanceWorld is mostly a facilitator for GgrsSchedule, so single threading avoids overhead

--- a/src/schedule_systems.rs
+++ b/src/schedule_systems.rs
@@ -6,8 +6,8 @@
 //! (save, load, advance) to the corresponding bevy_ggrs schedules.
 
 use crate::{
-    AdvanceWorld, Checksum, ConfirmedFrameCount, FixedTimestepData, LoadWorld, LocalInputs,
-    LocalPlayers, MaxPredictionWindow, PlayerInputs, ReadInputs, RollbackFrameCount,
+    AdvanceWorld, Checksum, ConfirmedFrameCount, FixedTimestepData, GgrsFrameTiming, LoadWorld,
+    LocalInputs, LocalPlayers, MaxPredictionWindow, PlayerInputs, ReadInputs, RollbackFrameCount,
     RollbackFrameRate, SaveWorld, Session, SyncTestMismatch,
 };
 use bevy::prelude::*;
@@ -79,6 +79,7 @@ pub(crate) fn run_ggrs_schedules<T: Config>(world: &mut World) {
         }
     }
 
+    world.insert_resource(GgrsFrameTiming::new(fps_delta, time_data.accumulator));
     world.insert_resource(time_data);
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -25,6 +25,43 @@ impl Default for RollbackFrameRate {
     }
 }
 
+/// Presentation timing from the most recent GGRS driver pass.
+///
+/// Updated after the driver runs and not rolled back. Use it for interpolation,
+/// not deterministic game logic. Values are zero before the first driver pass.
+#[derive(Resource, Clone, Copy, Debug, Default)]
+pub struct GgrsFrameTiming {
+    timestep: Duration,
+    overstep: Duration,
+}
+
+impl GgrsFrameTiming {
+    pub(crate) fn new(timestep: Duration, overstep: Duration) -> Self {
+        Self { timestep, overstep }
+    }
+
+    /// Timestep used by the most recent GGRS driver pass.
+    pub fn timestep(&self) -> Duration {
+        self.timestep
+    }
+
+    /// Accumulator remaining after the most recent driver pass.
+    pub fn overstep(&self) -> Duration {
+        self.overstep
+    }
+
+    /// Accumulator as a fraction of the timestep in the range `[0, 1)`.
+    ///
+    /// Zero before the first driver pass.
+    pub fn overstep_fraction(&self) -> f32 {
+        if self.timestep.is_zero() {
+            0.0
+        } else {
+            self.overstep.as_secs_f32() / self.timestep.as_secs_f32()
+        }
+    }
+}
+
 /// A [`Time`] type for use with GGRS. This time is guaranteed to be in-sync with
 /// all peers, and reflect that exactly [`RollbackFrameCount`] frames have passed at
 /// the [`RollbackFrameRate`] rate. Note that in the [`GgrsSchedule`](`crate::GgrsSchedule`),

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -1,7 +1,7 @@
 #[allow(dead_code)]
 mod common;
 
-use bevy::prelude::*;
+use bevy::{prelude::*, time::TimeUpdateStrategy};
 use bevy_ggrs::{RollbackFrameCount, prelude::*};
 use common::{GgrsConfig, base_synctest_app, synctest_session};
 use core::time::Duration;
@@ -46,4 +46,48 @@ fn ggrs_time_survives_session_restart() {
         expected,
         "GgrsTime should track the restarted session's frame count"
     );
+}
+
+#[test]
+fn ggrs_frame_timing_tracks_driver_accumulator() {
+    let mut app = base_synctest_app(2);
+    app.insert_resource(RollbackFrameRate(50));
+    app.insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_millis(
+        10,
+    )));
+
+    // The resource exists before the driver has produced a timing sample.
+    let timing = app.world().resource::<GgrsFrameTiming>();
+    assert_eq!(timing.timestep(), Duration::ZERO);
+    assert_eq!(timing.overstep(), Duration::ZERO);
+    assert_eq!(timing.overstep_fraction(), 0.0);
+
+    // Bevy's first update initializes Time without advancing it.
+    app.update();
+    let timing = app.world().resource::<GgrsFrameTiming>();
+    assert_eq!(timing.timestep(), Duration::from_millis(20));
+    assert_eq!(
+        timing.overstep(),
+        Duration::ZERO,
+        "the initial zero delta should leave the accumulator empty"
+    );
+    assert_eq!(timing.overstep_fraction(), 0.0);
+
+    // Ten milliseconds is half of the 50 Hz rollback timestep.
+    app.update();
+    let timing = app.world().resource::<GgrsFrameTiming>();
+    assert_eq!(timing.timestep(), Duration::from_millis(20));
+    assert_eq!(timing.overstep(), Duration::from_millis(10));
+    assert_eq!(timing.overstep_fraction(), 0.5);
+
+    // The next ten milliseconds advances one rollback frame.
+    app.update();
+    let timing = app.world().resource::<GgrsFrameTiming>();
+    assert_eq!(timing.timestep(), Duration::from_millis(20));
+    assert_eq!(
+        timing.overstep(),
+        Duration::ZERO,
+        "a complete rollback timestep should drain the accumulator"
+    );
+    assert_eq!(timing.overstep_fraction(), 0.0);
 }


### PR DESCRIPTION
Expose GGRS frame timing as a resource so applications can interpolate smoothly between simulation frames.

Closes https://github.com/gschup/bevy_ggrs/issues/133